### PR TITLE
JdbcAccessMethod: cache connection objects

### DIFF
--- a/src/edu/washington/escience/myriad/accessmethod/JdbcAccessMethod.java
+++ b/src/edu/washington/escience/myriad/accessmethod/JdbcAccessMethod.java
@@ -7,8 +7,12 @@ import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import edu.washington.escience.myriad.Schema;
 import edu.washington.escience.myriad.TupleBatch;
@@ -33,12 +37,8 @@ public final class JdbcAccessMethod {
    */
   public static void tupleBatchInsert(final String driverClassName, final String connectionString,
       final String insertString, final TupleBatch tupleBatch) {
+    Connection jdbcConnection = JdbcConnectionManager.getConnection(driverClassName, connectionString);
     try {
-      /* Make sure JDBC driver is loaded */
-      Class.forName(driverClassName);
-      /* Connect to the database */
-      Connection jdbcConnection = DriverManager.getConnection(connectionString);
-
       /* Set up and execute the query */
       PreparedStatement statement = jdbcConnection.prepareStatement(insertString);
 
@@ -50,10 +50,6 @@ public final class JdbcAccessMethod {
       }
       statement.executeBatch();
       statement.close();
-      jdbcConnection.close();
-    } catch (ClassNotFoundException e) {
-      System.err.println(e.getMessage());
-      throw new RuntimeException(e.getMessage());
     } catch (SQLException e) {
       System.err.println(e.getMessage());
       throw new RuntimeException(e.getMessage());
@@ -70,23 +66,14 @@ public final class JdbcAccessMethod {
    */
   public static Iterator<TupleBatch> tupleBatchIteratorFromQuery(final String driverClassName,
       final String connectionString, final String queryString) {
+    Connection jdbcConnection = JdbcConnectionManager.getConnection(driverClassName, connectionString);
     try {
-      /* Make sure JDBC driver is loaded */
-      Class.forName(driverClassName);
-      /* Connect to the database */
-      Connection jdbcConnection = DriverManager.getConnection(connectionString);
-      /* Set read only on the connection */
-      jdbcConnection.setReadOnly(true);
-
       /* Set up and execute the query */
       Statement statement = jdbcConnection.createStatement();
       ResultSet resultSet = statement.executeQuery(queryString);
       ResultSetMetaData resultSetMetaData = resultSet.getMetaData();
 
       return new JdbcTupleBatchIterator(resultSet, Schema.fromResultSetMetaData(resultSetMetaData));
-    } catch (ClassNotFoundException e) {
-      System.err.println(e.getMessage());
-      throw new RuntimeException(e.getMessage());
     } catch (SQLException e) {
       System.err.println(e.getMessage());
       throw new RuntimeException(e.getMessage());
@@ -100,10 +87,81 @@ public final class JdbcAccessMethod {
 }
 
 /**
+ * JdbcConnectionManager reuses existing connections to JDBC databases if possible.
+ * 
+ * @author dhalperi
+ * 
+ */
+final class JdbcConnectionManager {
+  /** A cache of the connections that have been made. */
+  private static HashMap<Integer, Connection> connections;
+  /** A cache of the JDBC drivers that have been loaded. */
+  private static HashSet<Integer> loadedDrivers;
+  /** Class-specific magic number used to generate the hash code. */
+  private static final int MAGIC_HASHCODE1 = 247;
+  /** Class-specific magic number used to generate the hash code. */
+  private static final int MAGIC_HASHCODE2 = 89;
+
+  /**
+   * Gets a JDBC Connection object using the given driver name and connection string. This implementation will reuse
+   * connection objects when they succeed. This function returns null if the driver cannot be loaded or there is an
+   * error in making the connection.
+   * 
+   * @param driverClassName the JDBC driver name
+   * @param connectionString the string identifying the path to the database
+   * @return a connection to the requested database, or null during an exception
+   */
+  static Connection getConnection(final String driverClassName, final String connectionString) {
+    HashCodeBuilder hb = new HashCodeBuilder(MAGIC_HASHCODE1, MAGIC_HASHCODE2);
+
+    /* Expected invariant: connections and loadedDrivers are both null or both allocated */
+    if (connections == null) {
+      connections = new HashMap<Integer, Connection>();
+      loadedDrivers = new HashSet<Integer>();
+    }
+
+    /* Make sure JDBC driver is loaded */
+    int driverHash = hb.append(driverClassName).toHashCode();
+    if (!loadedDrivers.contains(driverHash)) {
+      try {
+        Class.forName(driverClassName);
+      } catch (ClassNotFoundException e) {
+        e.printStackTrace();
+        return null;
+      }
+      loadedDrivers.add(driverHash);
+    }
+
+    /* Check whether Connection has been made before, use same connection if exists */
+    int connectionHash = hb.append(connectionString).toHashCode();
+    Connection ret = connections.get(connectionHash);
+    if (ret != null) {
+      return ret;
+    }
+
+    /* Make new connection */
+    Connection jdbcConnection;
+    try {
+      jdbcConnection = DriverManager.getConnection(connectionString);
+    } catch (SQLException e) {
+      e.printStackTrace();
+      return null;
+    }
+
+    /* Store the connection and return it */
+    connections.put(connectionHash, jdbcConnection);
+    return jdbcConnection;
+  }
+
+  /** Inaccessible. */
+  private JdbcConnectionManager() {
+  }
+}
+
+/**
  * Wraps a JDBC ResultSet in a Iterator<TupleBatch>.
  * 
- * Implementation based on org.apache.commons.dbutils.ResultSetIterator. Requires ResultSet.isLast()
- * to be implemented.
+ * Implementation based on org.apache.commons.dbutils.ResultSetIterator. Requires ResultSet.isLast() to be implemented.
  * 
  * @author dhalperi
  * 
@@ -142,16 +200,15 @@ class JdbcTupleBatchIterator implements Iterator<TupleBatch> {
     List<Column> columns = ColumnFactory.allocateColumns(schema);
 
     /**
-     * Loop through resultSet, adding one row at a time. Stop when numTuples hits BATCH_SIZE or
-     * there are no more results.
+     * Loop through resultSet, adding one row at a time. Stop when numTuples hits BATCH_SIZE or there are no more
+     * results.
      */
     int numTuples;
     try {
       for (numTuples = 0; numTuples < TupleBatch.BATCH_SIZE; ++numTuples) {
         if (!resultSet.next()) {
-          Connection connection = resultSet.getStatement().getConnection();
           resultSet.getStatement().close();
-          connection.close(); /* Also closes the resultSet */
+          resultSet.close();
           break;
         }
         for (int colIdx = 0; colIdx < numFields; ++colIdx) {


### PR DESCRIPTION
Creating a JDBC connection is a pretty heavyweight operation. If we're
scanning multiple tables, the operators currently create a new
connection for each QueryScan, which thus results in lots of network
overhead.

Instead, cache each connection in a static object and reuse if
appropriate.

In this implementation, a cached JDBC connection will be reused if the
String parameters driverClassName and connectionString are equal.

Signed-off-by: Daniel Halperin dhalperi@cs.washington.edu
