### PR TITLE
build.gradle: add dependency on .classpath for test

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,8 @@ sourceSets {
 
 /* Compile, but don't run the speed tests when building the project. */
 check.dependsOn speedtestClasses
+/* Testing will fail if Eclipse .classpath hasn't been created. */
+testClasses.dependsOn eclipseClasspath
 
 /*
  * List the compile and runtime dependencies of all the tests.


### PR DESCRIPTION
Many of the tests read environment variables from .classpath. Propagate
that dependency into build.gradle.

Signed-off-by: Daniel Halperin dhalperi@cs.washington.edu
