### PR TITLE
api: fix bug introduced in f82ebc04d268e21880ccf6e7b0601987d79c17f5

### DIFF
--- a/src/edu/washington/escience/myriad/api/DatasetResource.java
+++ b/src/edu/washington/escience/myriad/api/DatasetResource.java
@@ -115,7 +115,7 @@ public final class DatasetResource {
    * A JSON-able wrapper for the expected wire message for a new dataset.
    * 
    */
-  class DatasetEncoding {
+  public static class DatasetEncoding {
     /** The name of the dataset. */
     @JsonProperty("relation_key")
     public RelationKey relationKey;


### PR DESCRIPTION
Apparently making this class not public static breaks deserialization.

Signed-off-by: Daniel Halperin dhalperi@cs.washington.edu
