### PR TITLE
myriadeploy: fix error-handling and syntax in scripts

### DIFF
--- a/myriadeploy/start_master.py
+++ b/myriadeploy/start_master.py
@@ -40,15 +40,14 @@ def read_workers(filename):
 
 def start_master(description, root, workers, MAX_MEM):
     for (hostname, port, username) in workers:
-    	cmd = "cd %s/%s-files; nohup java -cp myriad-0.1.jar:conf -Djava.library.path=sqlite4java-282 " % (root, description) + MAX_MEM + " edu.washington.escience.myriad.daemon.MasterDaemon %s 0</dev/null 1>master_stdout 2>master_stderr &" % (description);
-    	args = ["ssh", "%s@%s" % (username, hostname), cmd];
-   	#print args
+    	cmd = "cd %s/%s-files && nohup java -cp myriad-0.1.jar:conf -Djava.library.path=sqlite4java-282 " % (root, description) + MAX_MEM + " edu.washington.escience.myriad.daemon.MasterDaemon %s 0</dev/null 1>master_stdout 2>master_stderr &" % (description)
+    	args = ["ssh", "%s@%s" % (username, hostname), cmd]
     	if subprocess.call(args):
         	print >> sys.stderr, "error starting master %s" % (hostname)
         print hostname
 	# don't start workers too quickly before master is ready
 	time.sleep(0.5)
-    	break;
+    	break
 
 def main(argv):
     # Usage

--- a/myriadeploy/start_workers.py
+++ b/myriadeploy/start_workers.py
@@ -42,8 +42,8 @@ def start_workers(description, root, workers, MAX_MEM):
     id = 0
     for (hostname, port, username) in workers:
 	if id != 0:
-  	    cmd = "cd %s/%s-files; nohup java -cp myriad-0.1.jar:conf -Djava.library.path=sqlite4java-282 " % (root, description) + MAX_MEM + " edu.washington.escience.myriad.parallel.Worker --workingDir %s/worker_%d 0</dev/null 1>worker_%d_stdout 2>worker_%d_stderr &" % (description, id, id, id);
-    	    args = ["ssh", "%s@%s" % (username, hostname), cmd];
+  	    cmd = "cd %s/%s-files && nohup java -cp myriad-0.1.jar:conf -Djava.library.path=sqlite4java-282 " % (root, description) + MAX_MEM + " edu.washington.escience.myriad.parallel.Worker --workingDir %s/worker_%d 0</dev/null 1>worker_%d_stdout 2>worker_%d_stderr &" % (description, id, id, id)
+    	    args = ["ssh", "%s@%s" % (username, hostname), cmd]
 	    #print args
 	    if subprocess.call(args):
 	        print >> sys.stderr, "error starting worker %s" % (hostname)
@@ -65,9 +65,9 @@ def main(argv):
     DESCRIPTION = argv[1]
     EXPT_ROOT = argv[2]
     WORKERS_FILE = argv[3]
-    MAX_MEM = "";
+    MAX_MEM = ""
     if len(argv) > 4:
-        MAX_MEM = argv[4];
+        MAX_MEM = argv[4]
 
     # Figure out the master and workers
     workers = read_workers(WORKERS_FILE)


### PR DESCRIPTION
Instead of doing `cmd1 ; cmd2` we really want to do `cmd1 && cmd2` so
that `cmd2` is not executed when `cmd1` fails. This also means that
better error codes will get passed to the script.

(What was happening: the `cd` failed and then `startMaster.py`, etc.,
were creating files in other directories.)

Also, Python doesn't use `;` at the end of lines :)

Signed-off-by: Daniel Halperin dhalperi@cs.washington.edu
