### PR TITLE
SystemTestBase: wait for all workers to connect before starting test

### DIFF
--- a/test/edu/washington/escience/myriad/systemtest/SystemTestBase.java
+++ b/test/edu/washington/escience/myriad/systemtest/SystemTestBase.java
@@ -10,7 +10,9 @@ import java.lang.ProcessBuilder.Redirect;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -299,6 +301,16 @@ public class SystemTestBase {
 
     startMaster();
     startWorkers();
+
+    /* Wait until all the workers have connected to the master. */
+    Set<Integer> targetWorkers = new HashSet<Integer>();
+    for (int i : WORKER_ID) {
+      targetWorkers.add(i);
+    }
+    while (!server.getAliveWorkers().containsAll(targetWorkers)) {
+      Thread.sleep(10);
+    }
+
     // for setting breakpoint
     if (System.currentTimeMillis() < 0) {
       System.out.println("Only for setting breakpoint. Never reach here");


### PR DESCRIPTION
This fixes some race conditions.
- Close #145
- I think this also resolves the issue in @jingjingwang's
  05e915d0ed7036d4bd15131e7c823c7bb05b7c9f

Signed-off-by: Daniel Halperin dhalperi@cs.washington.edu
