### PR TITLE
build.gradle: fix bug in Eclipse classpath

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -134,12 +134,6 @@ eclipse.classpath {
 
   file {
 
-    /* add conf folder to classpath */
-    withXml {
-      def node = it.asNode()
-      node.appendNode('classpathentry',[kind: 'lib', path: 'conf'])
-    }
-
   /* Ugly hack to stick the JNI pointer for sqlite into the .classpath file. */
     withXml {
       provider -> 


### PR DESCRIPTION
The pre-existing fix to add `conf` to Eclipse's `.classpath` file
doesn't play well with the new one: it appears on the build path twice.
The other fix to `conf` was broken w.r.t. gradle functionality; the new
one replaces it.

Signed-off-by: Daniel Halperin dhalperi@cs.washington.edu
