### PR TITLE
myriadeploy: don't ssh or remote rsync when hostname='localhost'

### DIFF
--- a/myriadeploy/deployment.cfg.local
+++ b/myriadeploy/deployment.cfg.local
@@ -2,7 +2,7 @@
 [deployment]
 path = /tmp/myria
 name = twoNodeLocalParallel
-# Uncomment if need to set a specific username
+# Uncomment if need to set a specific username; does not work for localhost
 #username = dhalperi
 # Uncomment to set the maximum heap size of the Java processes
 #max_heap_size=-Xmx2g

--- a/myriadeploy/deployment.cfg.sample
+++ b/myriadeploy/deployment.cfg.sample
@@ -2,7 +2,7 @@
 [deployment]
 path = /disk2/dhalperi
 name = testMyriadeploy
-# Uncomment if need to set a specific username
+# Uncomment if need to set a specific username; does not work for localhost
 #username = dhalperi
 # Uncomment to set the maximum heap size of the Java processes
 #max_heap_size=-Xmx2g

--- a/myriadeploy/setup_cluster.py
+++ b/myriadeploy/setup_cluster.py
@@ -29,18 +29,27 @@ given deployment configuration."""
         sys.exit(1)
 
 def remote_mkdir(hostname, dirname, username):
-    args = ["ssh", "%s@%s" % (username, hostname), "mkdir", "-p", dirname]
+    if hostname != 'localhost':
+        args = ["ssh", "%s@%s" % (username, hostname), "mkdir", "-p", dirname]
+    else:
+        args = ["mkdir", "-p", dirname]
     return subprocess.call(args)
 
 def copy_master_catalog(hostname, dirname, path, username):
     local_path = "%s/%s" % (dirname, "master.catalog")
-    remote_path = "%s@%s:%s/%s-files/%s" % (username, hostname, path, dirname, dirname)
+    if hostname != 'localhost':
+        remote_path = "%s@%s:%s/%s-files/%s" % (username, hostname, path, dirname, dirname)
+    else:
+        remote_path = "%s/%s-files/%s" % (path, dirname, dirname)
     args = ["rsync", "-avz", local_path, remote_path]
     return subprocess.call(args)
 
 def copy_worker_catalog(hostname, dirname, path, i, username):
     local_path = "%s/worker_%d" % (dirname, i)
-    remote_path = "%s@%s:%s/%s-files/%s" % (username, hostname, path, dirname, dirname)
+    if hostname != 'localhost':
+        remote_path = "%s@%s:%s/%s-files/%s" % (username, hostname, path, dirname, dirname)
+    else:
+        remote_path = "%s/%s-files/%s" % (path, dirname, dirname)
     args = ["rsync", "-avz", local_path, remote_path]
     return subprocess.call(args)
 
@@ -83,7 +92,10 @@ def copy_distribution(config):
     username = config['username']
 
     for (hostname, _) in nodes:
-        remote_path = "%s@%s:%s/%s-files" % (username, hostname, path, description)
+        if hostname != 'localhost':
+            remote_path = "%s@%s:%s/%s-files" % (username, hostname, path, description)
+        else:
+            remote_path = "%s/%s-files" % (path, description)
         to_copy = ["myriad-0.1.jar", "sqlite4java-282", "conf"]
         args = ["rsync", "-avz"] + to_copy + [remote_path]
         if subprocess.call(args):


### PR DESCRIPTION
Turns out CSE support has a cap on the number of times you can log into
a machine within 1 minute; going over this limit gets you banned for 30
minutes. It's easy to hit this ban when setting up a Myria cluster on
localhost--you just need 3 workers or more.

As a workaround, don't use ssh/remote rsync if hostname is localhost.
This also means we can't change usernames, so put a note in the
deployment files about that problem as well.

Signed-off-by: Daniel Halperin dhalperi@cs.washington.edu
