### PR TITLE
checkstyle: remove unused imports warning

### DIFF
--- a/.checkstyle-config
+++ b/.checkstyle-config
@@ -32,7 +32,6 @@ Slightly modified version of Sun Checks that better matches the default code for
     <module name="AvoidStarImport"/>
     <module name="IllegalImport"/>
     <module name="RedundantImport"/>
-    <module name="UnusedImports"/>
     <module name="MethodLength"/>
     <module name="ParameterNumber"/>
     <module name="EmptyForIteratorPad"/>


### PR DESCRIPTION
Java already warns us about this, and Eclipse already auto-fixes the
code. This was only leading to "false positives" when the classes were
only linked from Javadoc comments. I think this is a legitimate use, so
disable the checkstyle warning.

Signed-off-by: Daniel Halperin dhalperi@cs.washington.edu
