### PR TITLE
resume read at the time an accepted connection is to be released. The cu...

### DIFF
--- a/src/edu/washington/escience/myriad/parallel/ipc/IPCConnectionPool.java
+++ b/src/edu/washington/escience/myriad/parallel/ipc/IPCConnectionPool.java
@@ -79,8 +79,9 @@ public final class IPCConnectionPool implements ExternalResourceReleasable {
           if (ecc.numReferenced() <= 0) {
             // only close the connection if no one is using the connection.
             // And the connections are closed by the server side.
-            if (!cc.isClientChannel() && !c.isReadable())
+            if (!cc.isClientChannel() && !c.isReadable()) {
               IPCUtils.resumeRead(c);
+            }
             if (cc.isClientChannel() || (cc.isCloseRequested())) {
               final ChannelFuture cf = cc.getMostRecentWriteFuture();
               if (cf != null) {


### PR DESCRIPTION
...rrent protocol of closing a connection is that the client should send to the server a message before the server closes the connection. If the connection is made unreadable by the user code, the connection cannot be closed and will make the system hang at shutdown.
