### PR TITLE
build.gradle: make sure the jarfile is always named 'myriad'

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ apply plugin: "java"
 apply plugin: "eclipse"
 
 /* Set up group and version info for myriad */
+archivesBaseName = "myriad"
 group = "edu.washington.escience.myriad"
 version = "0.1"
 


### PR DESCRIPTION
Apparently before the name of the project directory determined the name
of the jar file created. See #160.

Close #160.

Signed-off-by: Daniel Halperin dhalperi@cs.washington.edu
