### PR TITLE
Remove exhaustive execution in RootOperator

### DIFF
--- a/src/edu/washington/escience/myriad/operator/Operator.java
+++ b/src/edu/washington/escience/myriad/operator/Operator.java
@@ -208,7 +208,7 @@ public abstract class Operator implements Serializable {
     if (!open) {
       throw new DbException("Operator not yet open");
     }
-    if (eos()) {
+    if (eos() || eoi()) {
       return null;
     }
 

--- a/src/edu/washington/escience/myriad/operator/RootOperator.java
+++ b/src/edu/washington/escience/myriad/operator/RootOperator.java
@@ -69,24 +69,15 @@ public abstract class RootOperator extends Operator {
   @Override
   protected final TupleBatch fetchNextReady() throws DbException {
     TupleBatch tb = null;
-    boolean hasData = true;
-    while (hasData) {
-      hasData = false;
-      while ((tb = child.nextReady()) != null) {
-        hasData = true;
-        consumeTuples(tb);
-      }
-      if (child.eoi()) {
-        hasData = true;
-        childEOI();
-        child.setEOI(false);
-      }
-      if (child.eos()) {
-        hasData = false;
-        childEOS();
-      }
+    tb = child.nextReady();
+    if (tb != null) {
+      consumeTuples(tb);
+    } else if (child.eoi()) {
+      childEOI();
+    } else if (child.eos()) {
+      childEOS();
     }
-    return null;
+    return tb;
   }
 
   /**
@@ -112,5 +103,18 @@ public abstract class RootOperator extends Operator {
   @Override
   public final Schema getSchema() {
     return child.getSchema();
+  }
+
+  /**
+   * process EOS and EOI logic.
+   * */
+  @Override
+  protected final void checkEOSAndEOI() {
+    if (child.eos()) {
+      setEOS();
+    } else if (child.eoi()) {
+      setEOI(true);
+      child.setEOI(false);
+    }
   }
 }

--- a/test/edu/washington/escience/myriad/systemtest/IterativeFlowControlTest.java
+++ b/test/edu/washington/escience/myriad/systemtest/IterativeFlowControlTest.java
@@ -110,7 +110,7 @@ public class IterativeFlowControlTest extends SystemTestBase {
         if (s[i][j]) {
           result.put(0, (long) i);
           result.put(1, (long) j);
-          LOGGER.debug(i + "\t" + j);
+          // LOGGER.debug(i + "\t" + j);
         }
       }
     }


### PR DESCRIPTION
The RootOperator tries to consume as much TBs as the child could produce. By this design the executor is not able to limit the execution of a simple ( scan -> shuffle ) task once the task gets started.

The new version remove the exhaustive execution behavior from RootOperator.
