### PR TITLE
Fix ProtobufTest failures

### DIFF
--- a/src/edu/washington/escience/myriad/parallel/ipc/ChannelContext.java
+++ b/src/edu/washington/escience/myriad/parallel/ipc/ChannelContext.java
@@ -891,6 +891,7 @@ public class ChannelContext {
         newConnection = false;
         registered = true;
         inPool = true;
+        registeredContext.incReference();
         channelPool.add(ownerChannel);
         unregisteredNewChannels.remove(ownerChannel);
         synchronized (channelRegisterLock) {

--- a/src/edu/washington/escience/myriad/parallel/ipc/IPCConnectionPool.java
+++ b/src/edu/washington/escience/myriad/parallel/ipc/IPCConnectionPool.java
@@ -580,7 +580,6 @@ public final class IPCConnectionPool implements ExternalResourceReleasable {
       }
 
       cc.registerNormal(remote.id, remote.registeredChannels, unregisteredChannels);
-      cc.getRegisteredChannelContext().incReference();
       if (LOGGER.isDebugEnabled()) {
         LOGGER.debug("Created a new registered channel from: " + myID + ", to: " + remote.id + ". Channel: " + channel);
       }
@@ -617,7 +616,6 @@ public final class IPCConnectionPool implements ExternalResourceReleasable {
         ch.setAttachment(cc);
         cc.connected();
         cc.registerNormal(myID, remote.registeredChannels, unregisteredChannels);
-        cc.getRegisteredChannelContext().incReference();
         return ch;
       } catch (Exception e) {
         if (LOGGER.isErrorEnabled()) {
@@ -1128,7 +1126,6 @@ public final class IPCConnectionPool implements ExternalResourceReleasable {
     inJVMShortMessageChannel.setAttachment(cc);
     cc.connected();
     cc.registerNormal(myID, myself.registeredChannels, unregisteredChannels);
-    cc.getRegisteredChannelContext().incReference();
 
     allPossibleChannels.add(serverChannel);
     scheduledTaskExecutor.scheduleAtFixedRate(recycler,


### PR DESCRIPTION
Finally I find the true reason of ProtobufTest random failures. 

It's a tiny concurrent bug in the IPC layer. Really hidden.

The reason that I failed to find it before is that ProtobufTest succeeded everytime in the exhaustive tests. So I thought the IPC layer should be of no problem. Really weird.
