### PR TITLE
fix a bug in LocalJoin.

### DIFF
--- a/src/edu/washington/escience/myriad/operator/LocalJoin.java
+++ b/src/edu/washington/escience/myriad/operator/LocalJoin.java
@@ -5,6 +5,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
@@ -289,17 +290,20 @@ public final class LocalJoin extends Operator {
 
     TupleBatch child1TB = null;
     TupleBatch child2TB = null;
-
     int numEOS = 0;
-    if (child1.eos()) {
-      numEOS = 1;
-    }
-    if (child2.eos()) {
-      numEOS += 1;
-    }
-    int numNoData = numEOS;
+    int numNoData = 0;
 
     while (numEOS < 2 && numNoData < 2) {
+
+      numEOS = 0;
+      if (child1.eos()) {
+        numEOS += 1;
+      }
+      if (child2.eos()) {
+        numEOS += 1;
+      }
+      numNoData = numEOS;
+
       child1TB = null;
       child2TB = null;
       if (!child1.eos()) {
@@ -350,6 +354,8 @@ public final class LocalJoin extends Operator {
         }
       }
     }
+    Preconditions.checkArgument(numEOS <= 2);
+    Preconditions.checkArgument(numNoData <= 2);
 
     checkEOSAndEOI();
     if (eoi() || eos()) {


### PR DESCRIPTION
numNoData needs to be initialized inside of the while loop, otherwise the while loop may exit earlier than it should be, which makes children can't consumer all the data that they already have, which is not expected in the current flow control design, which caused a query frozen.
Notice the current implementation may return a non-null TB while
self.eoi() == true, which violates our assumption but caused no problem
so far. The whole EOI/EOS design will be refactored in the future so I
didn't change it.
