### PR TITLE
Specify path per node in the deployment config file.

### DIFF
--- a/myriadeploy/deployment.cfg.local
+++ b/myriadeploy/deployment.cfg.local
@@ -1,6 +1,5 @@
 # Deployment configuration
 [deployment]
-path = /tmp/myria
 name = twoNodeLocalParallel
 # Uncomment if need to set a specific username; does not work for localhost
 #username = dhalperi
@@ -10,8 +9,8 @@ rest_port = 8753
 
 # Compute nodes configuration
 [master]
-localhost,8001
+localhost,8001,/tmp/myria
 
 [workers]
-localhost,9001
-localhost,9002
+localhost,9001,/tmp/myria
+localhost,9002,/tmp/myria

--- a/myriadeploy/deployment.cfg.sample
+++ b/myriadeploy/deployment.cfg.sample
@@ -1,6 +1,5 @@
 # Deployment configuration
 [deployment]
-path = /disk2/dhalperi
 name = testMyriadeploy
 # Uncomment if need to set a specific username; does not work for localhost
 #username = dhalperi
@@ -10,10 +9,14 @@ rest_port = 8753
 
 # Compute nodes configuration
 [master]
-orlando.cs.washington.edu,9001
+vega.cs.washington.edu,8001,/disk1/myria
 
 [workers]
-berlin.cs.washington.edu,9002
-dallas.cs.washington.edu,9002
-seoul.cs.washington.edu,9002
-newyork.cs.washington.edu,9002
+aldebaran.cs.washington.edu,9001,/disk1/myria
+aldebaran.cs.washington.edu,9002,/disk2/myria
+aldebaran.cs.washington.edu,9003,/disk3/myria
+aldebaran.cs.washington.edu,9004,/disk4/myria
+altair.cs.washington.edu,9001,/disk1/myria
+altair.cs.washington.edu,9002,/disk2/myria
+altair.cs.washington.edu,9003,/disk3/myria
+altair.cs.washington.edu,9004,/disk4/myria

--- a/myriadeploy/myriadeploy.py
+++ b/myriadeploy/myriadeploy.py
@@ -19,8 +19,6 @@ def read_config_file(filename='deployment.cfg'):
     # Extract values
     # .. description is the name of the configuration
     ret['description'] = config.get('deployment', 'name')
-    # .. path is the root path files will be stored on
-    ret['path'] = config.get('deployment', 'path')
     # .. username is the SSH username for remote commands. Default `whoami`
     try:
         ret['username'] = config.get('deployment', 'username')
@@ -29,14 +27,14 @@ def read_config_file(filename='deployment.cfg'):
     ret['rest_port'] = config.get('deployment', 'rest_port')
 
     # Helper function
-    def split_hostport_key(hostport):
-        "Splits host,port into a tuple (host, port)."
+    def split_hostportpath_key(hostport):
+        "Splits host,port,path into a tuple (host, port, path)."
         return tuple(hostport[0].split(','))
 
     # .. master is the master node of the cluster.
-    ret['master'] = split_hostport_key(config.items('master')[0])
+    ret['master'] = split_hostportpath_key(config.items('master')[0])
     # .. workers is a list of the worker nodes in the cluster.
-    ret['workers'] = [split_hostport_key(w) for w in config.items('workers')]
+    ret['workers'] = [split_hostportpath_key(w) for w in config.items('workers')]
     # .. nodes is master and workers
     ret['nodes'] = [ret['master']] + ret['workers']
     # .. max_heap_size is the Java maximum heap size

--- a/myriadeploy/remove_deployment.py
+++ b/myriadeploy/remove_deployment.py
@@ -15,23 +15,22 @@ def remote_rm(hostname, dirname, username):
 def rm_deployment(config):
     """Copies the master and worker catalogs to the remote hosts."""
     description = config['description']
-    path = config['path']
     master = config['master']
     workers = config['workers']
     username = config['username']
 
-    # Make directories on master
-    (hostname, _) = master
+    # Remove directories on master
+    (hostname, _, path) = master
     if remote_rm(hostname, "%s/%s-files" \
             % (path, description), username):
         raise Exception("Error removing directory on master %s" \
                 % (hostname,))
 
-    for (i, (hostname, _)) in enumerate(workers):
+    for (i, (hostname, _, path)) in enumerate(workers):
         # Workers are numbered from 1, not 0
         worker_id = i + 1
 
-        # Make directories on the worker
+        # Remove directories on the worker
         if remote_rm(hostname, "%s/%s-files" \
                 % (path, description), username):
             raise Exception("Error removing directory on worker %d %s" \

--- a/myriadeploy/setup_cluster.py
+++ b/myriadeploy/setup_cluster.py
@@ -6,7 +6,7 @@ import subprocess
 import sys
 
 def host_port_list(workers):
-    return [str(x) + ':' + str(y) for (x, y) in workers]
+    return [str(x) + ':' + str(y) for (x, y, _) in workers]
 
 def make_catalog(config):
     """Creates a Myria catalog (running the Java program to do so) from the
@@ -24,6 +24,7 @@ given deployment configuration."""
             description, \
             str(len(nodes))]
     args += host_port_list(nodes)
+
     if subprocess.call(args):
         print >> sys.stderr, "error making the Catalog"
         sys.exit(1)
@@ -56,13 +57,12 @@ def copy_worker_catalog(hostname, dirname, path, i, username):
 def copy_catalogs(config):
     """Copies the master and worker catalogs to the remote hosts."""
     description = config['description']
-    path = config['path']
     master = config['master']
     workers = config['workers']
     username = config['username']
 
     # Make directories on master
-    (hostname, _) = master
+    (hostname, _, path) = master
     if remote_mkdir(hostname, "%s/%s-files/%s" \
             % (path, description, description), username):
         raise Exception("Error making directory on master %s" \
@@ -71,7 +71,7 @@ def copy_catalogs(config):
     if copy_master_catalog(hostname, description, path, username):
         raise Exception("Error copying master.catalog to %s" % (hostname,))
 
-    for (i, (hostname, _)) in enumerate(workers):
+    for (i, (hostname, _, path)) in enumerate(workers):
         # Workers are numbered from 1, not 0
         worker_id = i + 1
 
@@ -88,10 +88,9 @@ def copy_distribution(config):
     "Copy the distribution (jar and libs and conf) to compute nodes."
     nodes = config['nodes']
     description = config['description']
-    path = config['path']
     username = config['username']
 
-    for (hostname, _) in nodes:
+    for (hostname, _, path) in nodes:
         if hostname != 'localhost':
             remote_path = "%s@%s:%s/%s-files" % (username, hostname, path, description)
         else:

--- a/myriadeploy/start_master.py
+++ b/myriadeploy/start_master.py
@@ -10,13 +10,12 @@ import sys
 def start_master(config):
     "Start the Myria master in the specified deployment."
     description = config['description']
-    path = config['path']
     master = config['master']
     username = config['username']
     max_heap_size = config['max_heap_size']
     rest_port = config['rest_port']
 
-    (hostname, _) = master
+    (hostname, _, path) = master
     cmd = "cd %s/%s-files; nohup java -cp myriad-0.1.jar:conf -Djava.library.path=sqlite4java-282 " % (path, description) + max_heap_size + " edu.washington.escience.myriad.daemon.MasterDaemon %s %s 0</dev/null 1>master_stdout 2>master_stderr &" % (description,rest_port)
     args = ["ssh", "%s@%s" % (username, hostname), cmd]
     if subprocess.call(args):

--- a/myriadeploy/start_workers.py
+++ b/myriadeploy/start_workers.py
@@ -10,13 +10,12 @@ import sys
 def start_workers(config):
     "Start all Myria workers in the specified deployment."
     description = config['description']
-    path = config['path']
     workers = config['workers']
     username = config['username']
     max_heap_size = config['max_heap_size']
 
     worker_id = 0
-    for (hostname, _) in workers:
+    for (hostname, _, path) in workers:
         worker_id = worker_id + 1
         cmd = "cd %s/%s-files; nohup java -cp myriad-0.1.jar:conf -Djava.library.path=sqlite4java-282 " % (path, description) + max_heap_size + " edu.washington.escience.myriad.parallel.Worker --workingDir %s/worker_%d 0</dev/null 1>worker_%d_stdout 2>worker_%d_stderr &" % (description, worker_id, worker_id, worker_id)
         args = ["ssh", "%s@%s" % (username, hostname), cmd]

--- a/myriadeploy/stop_all_by_force.py
+++ b/myriadeploy/stop_all_by_force.py
@@ -14,7 +14,7 @@ def stop_all(config):
     username = config['username']
 
     # Stop the Master
-    (hostname, _) = master
+    (hostname, _, _) = master
     cmd = "ssh %s@%s $'ps aux | grep edu.washington.escience.myriad.daemon.MasterDaemon | grep %s | grep -v grep | awk \\'{print $2}\\''" % (username, hostname, username)
     pids = subprocess.check_output(cmd, shell=True).split('\n')
     for pid in pids:
@@ -25,7 +25,7 @@ def stop_all(config):
 
     # Workers
     done = set()
-    for (hostname, _) in workers:
+    for (hostname, _, _) in workers:
         if hostname in done:
             continue
         done.add(hostname)

--- a/myriadeploy/update_myria_jar_only.py
+++ b/myriadeploy/update_myria_jar_only.py
@@ -12,10 +12,9 @@ def copy_distribution(config):
     "Copy the distribution (jar and libs and conf) to compute nodes."
     nodes = config['nodes']
     description = config['description']
-    path = config['path']
     username = config['username']
 
-    for (hostname, _) in nodes:
+    for (hostname, _, path) in nodes:
         if hostname != 'localhost':
             remote_path = "%s@%s:%s/%s-files" % (username, hostname, path, description)
         else:


### PR DESCRIPTION
The path for deploying files is not unique for the whole system anymore. One can now specify a path for each node, the master and all workers. Now, even workers in the same node can use different directories, which means that we can use parallellism inside a node, with different disks (and disk controllers).

The file myriadeploy/deployment.cfg.local maintains all nodes with the same directory.

On the other hand, the file myriadeploy/deployment.cfg.sample uses three machines, vega as master; aldebaran and altair as workers. The four disks we have on those worker machines are being used in this sample deployment configuration.
