### PR TITLE
Specify path per node in the deployment config file.

### DIFF
--- a/myriadeploy/deployment.cfg.sample
+++ b/myriadeploy/deployment.cfg.sample
@@ -1,19 +1,24 @@
 # Deployment configuration
 [deployment]
-path = /disk2/dhalperi
+path = /disk1/myria
 name = testMyriadeploy
 # Uncomment if need to set a specific username; does not work for localhost
 #username = dhalperi
 # Uncomment to set the maximum heap size of the Java processes
 #max_heap_size=-Xmx2g
-rest_port = 8753
+#rest_port = 8753
+rest_port = 8759
 
 # Compute nodes configuration
 [master]
-orlando.cs.washington.edu,9001
+vega.cs.washington.edu,8001
 
 [workers]
-berlin.cs.washington.edu,9002
-dallas.cs.washington.edu,9002
-seoul.cs.washington.edu,9002
-newyork.cs.washington.edu,9002
+aldebaran.cs.washington.edu,9001
+aldebaran.cs.washington.edu,9002,/disk2/myria
+aldebaran.cs.washington.edu,9003,/disk3/myria
+aldebaran.cs.washington.edu,9004,/disk4/myria
+altair.cs.washington.edu,9001
+altair.cs.washington.edu,9002,/disk2/myria
+altair.cs.washington.edu,9003,/disk3/myria
+altair.cs.washington.edu,9004,/disk4/myria

--- a/myriadeploy/myriadeploy.py
+++ b/myriadeploy/myriadeploy.py
@@ -20,7 +20,10 @@ def read_config_file(filename='deployment.cfg'):
     # .. description is the name of the configuration
     ret['description'] = config.get('deployment', 'name')
     # .. path is the root path files will be stored on
-    ret['path'] = config.get('deployment', 'path')
+    try:
+        ret['path'] = config.get('deployment', 'path')
+    except ConfigParser.NoOptionError:
+        ret['path'] = None
     # .. username is the SSH username for remote commands. Default `whoami`
     try:
         ret['username'] = config.get('deployment', 'username')
@@ -29,14 +32,14 @@ def read_config_file(filename='deployment.cfg'):
     ret['rest_port'] = config.get('deployment', 'rest_port')
 
     # Helper function
-    def split_hostport_key(hostport):
-        "Splits host,port into a tuple (host, port)."
+    def split_hostportpath_key(hostport):
+        "Splits host,port,path into a tuple (host, port, path)."
         return tuple(hostport[0].split(','))
 
     # .. master is the master node of the cluster.
-    ret['master'] = split_hostport_key(config.items('master')[0])
+    ret['master'] = split_hostportpath_key(config.items('master')[0])
     # .. workers is a list of the worker nodes in the cluster.
-    ret['workers'] = [split_hostport_key(w) for w in config.items('workers')]
+    ret['workers'] = [split_hostportpath_key(w) for w in config.items('workers')]
     # .. nodes is master and workers
     ret['nodes'] = [ret['master']] + ret['workers']
     # .. max_heap_size is the Java maximum heap size

--- a/myriadeploy/start_master.py
+++ b/myriadeploy/start_master.py
@@ -3,6 +3,7 @@
 "Start the Myria master in the specified deployment."
 
 import myriadeploy
+import setup_cluster
 
 import subprocess
 import sys
@@ -10,13 +11,13 @@ import sys
 def start_master(config):
     "Start the Myria master in the specified deployment."
     description = config['description']
-    path = config['path']
+    default_path = config['path']
     master = config['master']
     username = config['username']
     max_heap_size = config['max_heap_size']
     rest_port = config['rest_port']
 
-    (hostname, _) = master
+    (hostname, _, path) = setup_cluster.get_host_port_path(master, default_path)
     cmd = "cd %s/%s-files; nohup java -cp myriad-0.1.jar:conf -Djava.library.path=sqlite4java-282 " % (path, description) + max_heap_size + " edu.washington.escience.myriad.daemon.MasterDaemon %s %s 0</dev/null 1>master_stdout 2>master_stderr &" % (description,rest_port)
     args = ["ssh", "%s@%s" % (username, hostname), cmd]
     if subprocess.call(args):

--- a/myriadeploy/start_workers.py
+++ b/myriadeploy/start_workers.py
@@ -3,6 +3,7 @@
 "Start all Myria workers in the specified deployment."
 
 import myriadeploy
+import setup_cluster
 
 import subprocess
 import sys
@@ -10,14 +11,15 @@ import sys
 def start_workers(config):
     "Start all Myria workers in the specified deployment."
     description = config['description']
-    path = config['path']
+    default_path = config['path']
     workers = config['workers']
     username = config['username']
     max_heap_size = config['max_heap_size']
 
     worker_id = 0
-    for (hostname, _) in workers:
+    for worker in workers:
         worker_id = worker_id + 1
+        (hostname, port, path) = setup_cluster.get_host_port_path(worker, default_path)
         cmd = "cd %s/%s-files; nohup java -cp myriad-0.1.jar:conf -Djava.library.path=sqlite4java-282 " % (path, description) + max_heap_size + " edu.washington.escience.myriad.parallel.Worker --workingDir %s/worker_%d 0</dev/null 1>worker_%d_stdout 2>worker_%d_stderr &" % (description, worker_id, worker_id, worker_id)
         args = ["ssh", "%s@%s" % (username, hostname), cmd]
         if subprocess.call(args):

--- a/myriadeploy/stop_all_by_force.py
+++ b/myriadeploy/stop_all_by_force.py
@@ -14,7 +14,7 @@ def stop_all(config):
     username = config['username']
 
     # Stop the Master
-    (hostname, _) = master
+    (hostname, _, _) = master
     cmd = "ssh %s@%s $'ps aux | grep edu.washington.escience.myriad.daemon.MasterDaemon | grep %s | grep -v grep | awk \\'{print $2}\\''" % (username, hostname, username)
     pids = subprocess.check_output(cmd, shell=True).split('\n')
     for pid in pids:
@@ -25,7 +25,7 @@ def stop_all(config):
 
     # Workers
     done = set()
-    for (hostname, _) in workers:
+    for (hostname, _, _) in workers:
         if hostname in done:
             continue
         done.add(hostname)

--- a/myriadeploy/update_myria_jar_only.py
+++ b/myriadeploy/update_myria_jar_only.py
@@ -1,21 +1,23 @@
 #!/usr/bin/env python
 
 import myriadeploy
+import setup_cluster
 
 import subprocess
 import sys
 
 def host_port_list(workers):
-    return [str(x) + ':' + str(y) for (x, y) in workers]
+    return [str(worker[0]) + ':' + str(worker[1]) for worker in workers]
 
 def copy_distribution(config):
     "Copy the distribution (jar and libs and conf) to compute nodes."
     nodes = config['nodes']
     description = config['description']
-    path = config['path']
+    default_path = config['path']
     username = config['username']
 
-    for (hostname, _) in nodes:
+    for node in nodes:
+        (hostname, _, path) = setup_cluster.get_host_port_path(node, default_path)
         if hostname != 'localhost':
             remote_path = "%s@%s:%s/%s-files" % (username, hostname, path, description)
         else:


### PR DESCRIPTION
The path for deploying files may not unique for the whole system anymore. One can now specify a path for each node, the master and all workers. Now, even workers in the same node can use different directories, which means that we can use parallellism inside a node, with different disks (and disk controllers).

A default path can still be specified. The file myriadeploy/deployment.cfg.local shows the master using the default path, and the workers using another different directory.

The file myriadeploy/deployment.cfg.sample uses three machines, vega as master; aldebaran and altair as workers. The four disks we have on those worker machines are being used in this sample deployment configuration. /disk1/myria is the default path, others are specified node by node.
