### PR TITLE
Remove the `design for extension` checkstyle check

### DIFF
--- a/.checkstyle-config
+++ b/.checkstyle-config
@@ -75,7 +75,6 @@ Slightly modified version of Sun Checks that better matches the default code for
     </module>
     <module name="SimplifyBooleanExpression"/>
     <module name="SimplifyBooleanReturn"/>
-    <module name="DesignForExtension"/>
     <module name="FinalClass"/>
     <module name="HideUtilityClassConstructor"/>
     <module name="InterfaceIsType"/>


### PR DESCRIPTION
I don't think we get enough benefit from this warning, and there are at
least a few cases where we want to break their rules. See

https://github.com/uwescience/myriad/pull/227#commitcomment-3609751

@jingjingwang
@slxu

Signed-off-by: Daniel Halperin dhalperi@cs.washington.edu
