### PR TITLE
RFC LocalJoin: change constructor from Schema to List<String>

### DIFF
--- a/test/edu/washington/escience/myriad/systemtest/BroadcastTest.java
+++ b/test/edu/washington/escience/myriad/systemtest/BroadcastTest.java
@@ -12,8 +12,8 @@ import edu.washington.escience.myriad.Schema;
 import edu.washington.escience.myriad.TupleBatch;
 import edu.washington.escience.myriad.TupleBatchBuffer;
 import edu.washington.escience.myriad.Type;
-import edu.washington.escience.myriad.operator.LocalJoin;
 import edu.washington.escience.myriad.operator.DbQueryScan;
+import edu.washington.escience.myriad.operator.LocalJoin;
 import edu.washington.escience.myriad.operator.RootOperator;
 import edu.washington.escience.myriad.operator.SinkRoot;
 import edu.washington.escience.myriad.operator.TBQueueExporter;
@@ -65,7 +65,8 @@ public class BroadcastTest extends SystemTestBase {
     /* Set collect producer which will send data inner-joined */
     final DbQueryScan scan2 = new DbQueryScan(testtable2Key, schema);
 
-    final LocalJoin localjoin = new LocalJoin(bs, scan2, new int[] { 0 }, new int[] { 0 });
+    final ImmutableList<String> outputColumnNames = ImmutableList.of("id1", "name1", "id2", "name2");
+    final LocalJoin localjoin = new LocalJoin(outputColumnNames, bs, scan2, new int[] { 0 }, new int[] { 0 });
 
     final CollectProducer cp = new CollectProducer(localjoin, serverReceiveID, MASTER_ID);
 

--- a/test/edu/washington/escience/myriad/systemtest/OperatorTestUsingSQLiteStorage.java
+++ b/test/edu/washington/escience/myriad/systemtest/OperatorTestUsingSQLiteStorage.java
@@ -3,6 +3,7 @@ package edu.washington.escience.myriad.systemtest;
 import static org.junit.Assert.assertTrue;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -17,10 +18,10 @@ import edu.washington.escience.myriad.Schema;
 import edu.washington.escience.myriad.TupleBatch;
 import edu.washington.escience.myriad.TupleBatchBuffer;
 import edu.washington.escience.myriad.Type;
+import edu.washington.escience.myriad.operator.DbQueryScan;
 import edu.washington.escience.myriad.operator.DupElim;
 import edu.washington.escience.myriad.operator.LocalCountingJoin;
 import edu.washington.escience.myriad.operator.LocalJoin;
-import edu.washington.escience.myriad.operator.DbQueryScan;
 import edu.washington.escience.myriad.operator.RootOperator;
 import edu.washington.escience.myriad.operator.SinkRoot;
 import edu.washington.escience.myriad.operator.TBQueueExporter;
@@ -188,7 +189,7 @@ public class OperatorTestUsingSQLiteStorage extends SystemTestBase {
     final ShuffleConsumer sc2 =
         new ShuffleConsumer(sp2.getSchema(), table2ShuffleID, new int[] { WORKER_ID[0], WORKER_ID[1] });
 
-    final LocalJoin localjoin = new LocalJoin(sc1, sc2, new int[] { 0 }, new int[] { 0 });
+    final LocalJoin localjoin = new LocalJoin(outputColumnNames, sc1, sc2, new int[] { 0 }, new int[] { 0 });
 
     final CollectProducer cp1 = new CollectProducer(localjoin, serverReceiveID, MASTER_ID);
     final HashMap<Integer, RootOperator[]> workerPlans = new HashMap<Integer, RootOperator[]>();
@@ -241,7 +242,8 @@ public class OperatorTestUsingSQLiteStorage extends SystemTestBase {
     final ShuffleConsumer sc2 =
         new ShuffleConsumer(sp2.getSchema(), table2ShuffleID, new int[] { WORKER_ID[0], WORKER_ID[1] });
 
-    final LocalJoin localjoin = new LocalJoin(sc1, sc2, new int[] { 0 }, new int[] { 0 });
+    final List<String> joinOutputColumnNames = ImmutableList.of("id_1", "name_1", "id_2", "name_2");
+    final LocalJoin localjoin = new LocalJoin(joinOutputColumnNames, sc1, sc2, new int[] { 0 }, new int[] { 0 });
 
     final CollectProducer cp1 = new CollectProducer(localjoin, serverReceiveID, MASTER_ID);
     final HashMap<Integer, RootOperator[]> workerPlans = new HashMap<Integer, RootOperator[]>();

--- a/test/edu/washington/escience/myriad/systemtest/TransitiveClosureWithEOITest.java
+++ b/test/edu/washington/escience/myriad/systemtest/TransitiveClosureWithEOITest.java
@@ -15,13 +15,13 @@ import edu.washington.escience.myriad.TupleBatch;
 import edu.washington.escience.myriad.TupleBatchBuffer;
 import edu.washington.escience.myriad.Type;
 import edu.washington.escience.myriad.column.Column;
+import edu.washington.escience.myriad.operator.DbQueryScan;
 import edu.washington.escience.myriad.operator.DupElim;
 import edu.washington.escience.myriad.operator.IDBInput;
 import edu.washington.escience.myriad.operator.LocalJoin;
 import edu.washington.escience.myriad.operator.Merge;
 import edu.washington.escience.myriad.operator.Operator;
 import edu.washington.escience.myriad.operator.Project;
-import edu.washington.escience.myriad.operator.DbQueryScan;
 import edu.washington.escience.myriad.operator.RootOperator;
 import edu.washington.escience.myriad.operator.SinkRoot;
 import edu.washington.escience.myriad.operator.TBQueueExporter;
@@ -284,7 +284,8 @@ public class TransitiveClosureWithEOITest extends SystemTestBase {
     final ShuffleConsumer sc1 = new ShuffleConsumer(sp1.getSchema(), joinArray1ID, new int[] { WORKER_ID[0] });
     final ShuffleConsumer sc2 = new ShuffleConsumer(sp2.getSchema(), joinArray2ID, new int[] { WORKER_ID[0] });
 
-    final LocalJoin join = new LocalJoin(sc1, sc2, new int[] { 0 }, new int[] { 1 });
+    final List<String> joinOutputColumns = ImmutableList.of("follower1", "followee1", "follower2", "followee2");
+    final LocalJoin join = new LocalJoin(joinOutputColumns, sc1, sc2, new int[] { 0 }, new int[] { 1 });
     final Project proj = new Project(new int[] { 2, 1 }, join);
     ExchangePairID beforeDE = ExchangePairID.newID();
     final ShuffleProducer sp3 = new ShuffleProducer(proj, beforeDE, new int[] { WORKER_ID[0] }, pf0);


### PR DESCRIPTION
As the code has changed the code over time, we (@jingjingwang mainly,
also me) figured out that the "best" way to use LocalJoin is to not let
the user pass in the Schema: it's too easy to get it wrong, and we can
figure out column types and names from the childs' Schemas.

The downside is we can't change column names at the join, which we
probably want to be able to do. So, add a column names parameter and use
it.

Also, the old code used a hacky check in Schema.merge to automatically
resolve column name duplicates. (It only worked if left[i] == right[i]).
The new code does not call this function anymore, which means that we
need to pass in explicit names, and I fixed all unit tests that had this
issue.

We could also fix this by including a more robust version of
Schema.mergeAndRename() e.g. that renames all columns as they come up.

Signed-off-by: Daniel Halperin dhalperi@cs.washington.edu
