### PR TITLE
DeploymentUtils: fix logging and serialize processes

### DIFF
--- a/src/edu/washington/escience/myria/util/DeploymentUtils.java
+++ b/src/edu/washington/escience/myria/util/DeploymentUtils.java
@@ -149,7 +149,7 @@ public final class DeploymentUtils {
     StringBuilder builder = new StringBuilder();
     String path = workingDir + "/" + description + "-files";
     String workerDir = description + "/" + "worker_" + workerId;;
-    String classpath = "'libs/*'";
+    String classpath = "'conf:libs/*'";
     String librarypath = "sqlite4java-282";
     String heapSize = maxHeapSize;
     if (description == null) {
@@ -192,7 +192,7 @@ public final class DeploymentUtils {
     StringBuilder builder = new StringBuilder();
     builder.append("ssh " + address);
     builder.append(" cd " + workingDir + "/" + description + "-files;");
-    builder.append(" nohup java -cp 'libs/*'");
+    builder.append(" nohup java -cp 'conf:libs/*'");
     builder.append(" -Djava.util.logging.config.file=logging.properties");
     builder.append(" -Dlog4j.configuration=log4j.properties");
     builder.append(" -Djava.library.path=sqlite4java-282");
@@ -313,8 +313,8 @@ public final class DeploymentUtils {
   private static void startAProcess(final String cmd) {
     LOGGER.info(cmd);
     try {
-      new ProcessBuilder().inheritIO().command(cmd.split(" ")).start();
-    } catch (IOException e) {
+      new ProcessBuilder().inheritIO().command(cmd.split(" ")).start().waitFor();
+    } catch (IOException | InterruptedException e) {
       e.printStackTrace();
       throw new RuntimeException(e);
     }


### PR DESCRIPTION
1. The Deployment utilities didn't include the conf/ directory in the
   classpath. So, the only way that logging worked is that it found the
   log4j.properties file in the myria-0.1.jar. This is broken behavior,
   but it worked anyway.
   
   Since @7andrew7 added hadoop, that jar must also contain a
   log4j.properties. Since 'libs/*' completes to 'hadoop:...myria:...',
   the hadoop log4.properties was being found first and hence
   over-riding the log4j.properties in the myria jar.
   
   Fix this by doing the right thing from the start: put 'conf' ahead of
   'libs/*' in the classpath. Then the log4j.properties in 'conf' will
   be found first and will be the one that is used.
2. The deployment utils start processes in parallel. This is broken in
   lots of ways:
     1) The mkdir command doesn't finish before the CatalogMaker runs,
        so the CatalogMaker fails.
     2) The rsync to localhost (deployment.cfg.local, e.g.), starts
        multiple parallel rsync jobs to the same file at the same time,
    which causes both extra I/O and occasional checksum errors as
    multiple rsync jobs overwrite each other's work.
   Fix this by serializing the process launch.

Signed-off-by: Daniel Halperin dhalperi@cs.washington.edu
