### PR TITLE
systemtests: fail individual tests after 120s

### DIFF
--- a/systemtest/edu/washington/escience/myria/systemtest/SystemTestBase.java
+++ b/systemtest/edu/washington/escience/myria/systemtest/SystemTestBase.java
@@ -28,6 +28,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.TestRule;
 import org.junit.rules.TestWatcher;
+import org.junit.rules.Timeout;
 import org.junit.runner.Description;
 import org.slf4j.LoggerFactory;
 
@@ -68,6 +69,11 @@ public class SystemTestBase {
       LOGGER.warn("*********************************************");
     };
   };
+
+  /** Automatically fail system tests that take longer than this many milliseconds. */
+  private final int SYSTEM_TEST_TIMEOUT_MILLIS = 120 * 1000;
+  @Rule
+  public TestRule globalTimeout = new Timeout(SYSTEM_TEST_TIMEOUT_MILLIS);
 
   /** The logger for this class. */
   protected static final org.slf4j.Logger LOGGER = LoggerFactory.getLogger(SystemTestBase.class);


### PR DESCRIPTION
Usually the system tests complete in ~10 minutes on my computer, and
sometimes I have to kill them after 30 minutes.

These are the tests that, on my computer, often don't pass after 60s:

```
FTModeTest. abandonTest
FTModeTest. rejoinTest
FlowControlTest. flowControlTest
QueryFailureTest. workerInitFailureTest
```

There appear to be some bugs related to flow control and/or fault
tolerance and/or query failure.

Add a 120s time limit (per test case) to all system tests, so that the
test suite will eventually complete. We might even try and bring this
limit down as we try to get the system into better working shape.

Signed-off-by: Daniel Halperin dhalperi@cs.washington.edu
