### PR TITLE
Simple script to kill all java processes on a cluster.  Only the owner's...

### DIFF
--- a/myriadeploy/kill_all_java_processes.py
+++ b/myriadeploy/kill_all_java_processes.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+
+"Kill all Java processes owned by the current user on the given cluster."
+
+import myriadeploy
+
+import subprocess
+import sys
+
+def get_hostname(node):
+    return node[0]
+
+def kill_java(host_entry):
+    host = get_hostname(host_entry)
+    cmd = ['ssh', host, 'killall -KILL -v java']
+    subprocess.call(cmd)
+
+def stop_all(config):
+    master = config['master']
+    workers = config['workers']
+
+    # Stop the Master
+    kill_java(master)
+
+    for worker in workers:
+        kill_java(worker)
+
+
+def main(argv):
+    if len(argv) != 2:
+        print >> sys.stderr, "Usage: %s <deployment.cfg>" % (argv[0])
+        sys.exit(1)
+
+    config = myriadeploy.read_config_file(argv[1])
+
+    stop_all(config)
+
+if __name__ == "__main__":
+    main(sys.argv)


### PR DESCRIPTION
... processes are affected

This runs on Mac and Linux, unlike stop_all_by_force.py.
