### PR TITLE
clean the logic of generateSchema() in operators

### DIFF
--- a/src/edu/washington/escience/myria/operator/MergeJoin.java
+++ b/src/edu/washington/escience/myria/operator/MergeJoin.java
@@ -194,9 +194,6 @@ public final class MergeJoin extends BinaryOperator {
 
     this.ascending = ascending;
 
-    if (left != null && right != null) {
-      generateSchema();
-    }
   }
 
   /**

--- a/src/edu/washington/escience/myria/operator/RightHashJoin.java
+++ b/src/edu/washington/escience/myria/operator/RightHashJoin.java
@@ -179,9 +179,6 @@ public final class RightHashJoin extends BinaryOperator {
     leftAnswerColumns = MyriaArrayUtils.checkSet(answerColumns1);
     rightAnswerColumns = MyriaArrayUtils.checkSet(answerColumns2);
 
-    if (left != null && right != null) {
-      generateSchema();
-    }
   }
 
   /**
@@ -378,8 +375,6 @@ public final class RightHashJoin extends BinaryOperator {
   public void init(final ImmutableMap<String, Object> execEnvVars) throws DbException {
     final Operator right = getRight();
     rightHashTableIndices = new TIntObjectHashMap<TIntList>();
-
-    generateSchema();
 
     rightHashTable = new TupleBuffer(right.getSchema());
     ans = new TupleBatchBuffer(getSchema());

--- a/src/edu/washington/escience/myria/operator/SymmetricHashJoin.java
+++ b/src/edu/washington/escience/myria/operator/SymmetricHashJoin.java
@@ -286,9 +286,6 @@ public final class SymmetricHashJoin extends BinaryOperator {
     leftAnswerColumns = MyriaArrayUtils.checkSet(answerColumns1);
     rightAnswerColumns = MyriaArrayUtils.checkSet(answerColumns2);
 
-    if (left != null && right != null) {
-      generateSchema();
-    }
   }
 
   /**
@@ -612,8 +609,6 @@ public final class SymmetricHashJoin extends BinaryOperator {
     final Operator right = getRight();
     leftHashTableIndices = new TIntObjectHashMap<TIntList>();
     rightHashTableIndices = new TIntObjectHashMap<TIntList>();
-
-    generateSchema();
 
     hashTable1 = new TupleBuffer(left.getSchema());
     hashTable2 = new TupleBuffer(right.getSchema());


### PR DESCRIPTION
- `generateSchema()` should be only called by `getSchema()` in `Operator`. It otherwise doesn't do anything.
