### PR TITLE
Fixed postgresql type double conversion bug

### DIFF
--- a/src/edu/washington/escience/myria/accessmethod/JdbcAccessMethod.java
+++ b/src/edu/washington/escience/myria/accessmethod/JdbcAccessMethod.java
@@ -294,9 +294,13 @@ public final class JdbcAccessMethod extends AccessMethod {
       case BOOLEAN_TYPE:
         return "BOOLEAN";
       case DOUBLE_TYPE:
-        return "DOUBLE";
       case FLOAT_TYPE:
-        return "DOUBLE";
+        switch (dbms) {
+          case MyriaConstants.STORAGE_SYSTEM_POSTGRESQL:
+            return "DOUBLE PRECISION";
+          default:
+            return "DOUBLE";
+        }
       case INT_TYPE:
         return "INTEGER";
       case LONG_TYPE:

--- a/systemtest/edu/washington/escience/myria/accessmethod/JdbcAccessMethodTest.java
+++ b/systemtest/edu/washington/escience/myria/accessmethod/JdbcAccessMethodTest.java
@@ -64,7 +64,7 @@ public class JdbcAccessMethodTest {
 
     /* First, insert tuples into the database. */
     final int expectedNumResults = 250;
-    TupleRangeSource source = new TupleRangeSource(expectedNumResults, Type.INT_TYPE);
+    TupleRangeSource source = new TupleRangeSource(expectedNumResults, Type.DOUBLE_TYPE);
     final Schema schema = source.getSchema();
     final RelationKey relation = RelationKey.of("myria", "test", dbms);
     DbInsert insert = new DbInsert(source, relation, jdbcInfo, true);


### PR DESCRIPTION
double is actually double precision in postgresql: http://www.postgresql.org/docs/7.4/static/datatype.html#DATATYPE-NUMERIC

I did not add a new test but I changed the original test testInsertTuplesAndCountThem to insert type double instead of int.
