### PR TITLE
Fix race condition on server

### DIFF
--- a/src/edu/washington/escience/myria/parallel/Server.java
+++ b/src/edu/washington/escience/myria/parallel/Server.java
@@ -1060,12 +1060,10 @@ public final class Server {
           } else {
             status = Status.SUCCESS;
           }
-          catalog.queryFinished(queryID, startTime, endTime, elapsedNanos, status, message);
-          activeQueries.remove(queryID);
 
           if (future.isSuccess()) {
             if (LOGGER.isInfoEnabled()) {
-              LOGGER.info("The query #{} succeeds. Time elapse: {}.", queryID, DateTimeUtils
+              LOGGER.info("Query #{} succeeded. Time elapsed: {}.", queryID, DateTimeUtils
                   .nanoElapseToHumanReadable(elapsedNanos));
             }
             if (mqp.getRootOperator() instanceof SinkRoot) {
@@ -1074,11 +1072,18 @@ public final class Server {
             // TODO success management.
           } else {
             if (LOGGER.isInfoEnabled()) {
-              LOGGER.info("The query #{} failes. Time elapse: {}. Failure cause is {}.", queryID, DateTimeUtils
+              LOGGER.info("Query #{} failed. Time elapsed: {}. Failure cause is {}.", queryID, DateTimeUtils
                   .nanoElapseToHumanReadable(elapsedNanos), future.getCause());
             }
             // TODO failure management.
           }
+
+          catalog.queryFinished(queryID, startTime, endTime, elapsedNanos, status, message);
+          /*
+           * This should be the last line of code -- the query should not be removed from activeQueries until all the
+           * metadata is up to date.
+           */
+          activeQueries.remove(queryID);
         }
       });
 


### PR DESCRIPTION
We use activeQueries.contains(queryId) to tell if queryId
has finished. Thus we shouldn't remove it until all the
other updates are done.

Fix #452 
