### PR TITLE
StatefulApplyTest: fix & test for bug #547

### DIFF
--- a/src/edu/washington/escience/myria/expression/evaluate/Evaluator.java
+++ b/src/edu/washington/escience/myria/expression/evaluate/Evaluator.java
@@ -7,6 +7,7 @@ import edu.washington.escience.myria.Schema;
 import edu.washington.escience.myria.Type;
 import edu.washington.escience.myria.expression.Expression;
 import edu.washington.escience.myria.expression.ExpressionOperator;
+import edu.washington.escience.myria.expression.StateExpression;
 import edu.washington.escience.myria.expression.VariableExpression;
 
 /**
@@ -24,13 +25,19 @@ public abstract class Evaluator {
   private final ExpressionOperatorParameter parameters;
 
   /**
+   * True if the expression uses state.
+   */
+  private final boolean needsState;
+
+  /**
    * @param expression the expression to be evaluated
    * @param parameters parameters that are passed to the expression
    */
   public Evaluator(final Expression expression, final ExpressionOperatorParameter parameters) {
-    this.expression = expression;
-    Preconditions.checkNotNull(parameters.getSchema());
-    this.parameters = parameters;
+    this.expression = Preconditions.checkNotNull(expression, "expression");
+    this.parameters = Preconditions.checkNotNull(parameters, "parameters");
+    Preconditions.checkNotNull(parameters.getSchema(), "parameters.getSchema()");
+    needsState = getExpression().hasOperator(StateExpression.class);
   }
 
   /**
@@ -113,5 +120,12 @@ public abstract class Evaluator {
    */
   public boolean isConstant() {
     return getExpression().isConstant();
+  }
+
+  /**
+   * @return true if the expression accesses the state.
+   */
+  public boolean needsState() {
+    return needsState;
   }
 }

--- a/src/edu/washington/escience/myria/expression/evaluate/GenericEvaluator.java
+++ b/src/edu/washington/escience/myria/expression/evaluate/GenericEvaluator.java
@@ -16,7 +16,6 @@ import edu.washington.escience.myria.column.builder.ColumnFactory;
 import edu.washington.escience.myria.column.builder.WritableColumn;
 import edu.washington.escience.myria.expression.Expression;
 import edu.washington.escience.myria.expression.ExpressionOperator;
-import edu.washington.escience.myria.expression.StateExpression;
 import edu.washington.escience.myria.expression.VariableExpression;
 import edu.washington.escience.myria.operator.Apply;
 import edu.washington.escience.myria.operator.StatefulApply;
@@ -39,11 +38,6 @@ public class GenericEvaluator extends Evaluator {
   private EvalInterface evaluator;
 
   /**
-   * True if the expression uses state.
-   */
-  private final boolean needsState;
-
-  /**
    * Default constructor.
    * 
    * @param expression the expression for the evaluator
@@ -51,7 +45,6 @@ public class GenericEvaluator extends Evaluator {
    */
   public GenericEvaluator(final Expression expression, final ExpressionOperatorParameter parameters) {
     super(expression, parameters);
-    needsState = getExpression().hasOperator(StateExpression.class);
   }
 
   /**
@@ -61,7 +54,8 @@ public class GenericEvaluator extends Evaluator {
    */
   @Override
   public void compile() throws DbException {
-    Preconditions.checkArgument(needsCompiling(), "This expression does not need to be compiled.");
+    Preconditions.checkArgument(needsCompiling() || (getStateSchema() != null),
+        "This expression does not need to be compiled.");
 
     String javaExpression = getJavaExpression();
     IScriptEvaluator se;
@@ -135,12 +129,5 @@ public class GenericEvaluator extends Evaluator {
       eval(tb, row, ret, null);
     }
     return ret.build();
-  }
-
-  /**
-   * @return true if the expression accesses the state.
-   */
-  public boolean needsState() {
-    return needsState;
   }
 }


### PR DESCRIPTION
Fix GenericEvaluator for StatefulApply. Basically, the old code doesn't
let you compile expressions that copy from the child input or produce
constants (!needsCompiling()) as a way of preventing the caller from
using the tuple-wise eval method when they should be processing a
TupleBatch in O(1) steps.

However, for StatefulApply's updateExpressions we need to run them
row-at-a-time and hence we must compile them. Enable this by updating
the guard condition in GenericEvaluator.compile() from
`needsCompiling()` to `needsCompiling() || (getStateSchema() != null)`
so that it can be compiled for StatefulApply.

Also add a test of a simple StatefulApply that simply copies its input.

Fix #547 
