### PR TITLE
Dynamic attribute order in LeapFrogJoin

### DIFF
--- a/src/edu/washington/escience/myria/api/encoding/LeapFrogJoinEncoding.java
+++ b/src/edu/washington/escience/myria/api/encoding/LeapFrogJoinEncoding.java
@@ -9,7 +9,6 @@ import edu.washington.escience.myria.operator.LeapFrogJoin;
 public class LeapFrogJoinEncoding extends NaryOperatorEncoding<LeapFrogJoin> {
 
   public List<String> argColumnNames;
-  public boolean[] indexOnFirst;
   @Required
   public int[][][] joinFieldMapping;
   @Required
@@ -17,6 +16,6 @@ public class LeapFrogJoinEncoding extends NaryOperatorEncoding<LeapFrogJoin> {
 
   @Override
   public LeapFrogJoin construct(ConstructArgs args) throws MyriaApiException {
-    return new LeapFrogJoin(null, joinFieldMapping, outputFieldMapping, argColumnNames, indexOnFirst);
+    return new LeapFrogJoin(null, joinFieldMapping, outputFieldMapping, argColumnNames);
   }
 }

--- a/systemtest/edu/washington/escience/myria/systemtest/MultiwayJoinTest.java
+++ b/systemtest/edu/washington/escience/myria/systemtest/MultiwayJoinTest.java
@@ -215,9 +215,7 @@ public class MultiwayJoinTest extends SystemTestBase {
     int[][][] fieldMap = new int[][][] { { { 0, 0 }, { 1, 0 } } };
     int[][] outputMap = new int[][] { { 0, 0 }, { 0, 1 }, { 1, 0 }, { 1, 1 } };
 
-    final LeapFrogJoin localjoin =
-        new LeapFrogJoin(new Operator[] { o1, o2 }, fieldMap, outputMap, outputColumnNames, new boolean[] {
-            false, false });
+    final LeapFrogJoin localjoin = new LeapFrogJoin(new Operator[] { o1, o2 }, fieldMap, outputMap, outputColumnNames);
     localjoin.getSchema();
     final CollectProducer cp1 = new CollectProducer(localjoin, serverReceiveID, MASTER_ID);
     final HashMap<Integer, RootOperator[]> workerPlans = new HashMap<Integer, RootOperator[]>();

--- a/test/edu/washington/escience/myria/operator/LeapFrogJoinTest.java
+++ b/test/edu/washington/escience/myria/operator/LeapFrogJoinTest.java
@@ -43,7 +43,7 @@ public class LeapFrogJoinTest {
 
     int[][][] fieldMap = new int[][][] { { { 0, 0 }, { 1, 0 } } };
     int[][] outputMap = new int[][] { { 0, 0 }, { 0, 1 }, { 1, 0 }, { 1, 1 } };
-    NAryOperator join = new LeapFrogJoin(children, fieldMap, outputMap, outputColumnNames, null);
+    NAryOperator join = new LeapFrogJoin(children, fieldMap, outputMap, outputColumnNames);
     join.open(null);
     TupleBatch tb;
     TupleBatchBuffer batches = new TupleBatchBuffer(outputSchema);
@@ -81,8 +81,7 @@ public class LeapFrogJoinTest {
     final Schema outputSchema =
         new Schema(ImmutableList.of(Type.LONG_TYPE, Type.LONG_TYPE, Type.LONG_TYPE), outputColumnNames);
     LeapFrogJoin join =
-        new LeapFrogJoin(new Operator[] { orderR, orderS, orderT }, fieldMap, outputMap, outputColumnNames,
-            new boolean[] { true, true, true });
+        new LeapFrogJoin(new Operator[] { orderR, orderS, orderT }, fieldMap, outputMap, outputColumnNames);
     join.open(null);
     TupleBatch tb;
     TupleBatchBuffer batches = new TupleBatchBuffer(outputSchema);
@@ -125,8 +124,7 @@ public class LeapFrogJoinTest {
     final Schema outputSchema =
         new Schema(ImmutableList.of(Type.LONG_TYPE, Type.LONG_TYPE, Type.LONG_TYPE), outputColumnNames);
     LeapFrogJoin join =
-        new LeapFrogJoin(new Operator[] { orderR, orderS, orderT }, fieldMap, outputMap, outputColumnNames,
-            new boolean[] { true, true, false });
+        new LeapFrogJoin(new Operator[] { orderR, orderS, orderT }, fieldMap, outputMap, outputColumnNames);
     join.open(null);
     TupleBatch tb;
     TupleBatchBuffer batches = new TupleBatchBuffer(outputSchema);
@@ -180,7 +178,7 @@ public class LeapFrogJoinTest {
         new Schema(ImmutableList.of(Type.LONG_TYPE, Type.LONG_TYPE, Type.LONG_TYPE, Type.LONG_TYPE), outputColumnNames);
     LeapFrogJoin join =
         new LeapFrogJoin(new Operator[] { orderR, orderS, orderT, orderK, orderM }, fieldMap, outputMap,
-            outputColumnNames, new boolean[] { false, false, false, false, true });
+            outputColumnNames);
     join.open(TestEnvVars.get());
     TupleBatch tb;
     TupleBatchBuffer batches = new TupleBatchBuffer(outputSchema);
@@ -218,8 +216,7 @@ public class LeapFrogJoinTest {
     final ImmutableList<String> outputColumnNames = ImmutableList.of("x", "y");
     final Schema outputSchema = new Schema(ImmutableList.of(Type.INT_TYPE, Type.INT_TYPE), outputColumnNames);
     LeapFrogJoin join =
-        new LeapFrogJoin(new Operator[] { orderR, orderS, orderT }, fieldMap, outputMap, outputColumnNames,
-            new boolean[] { false, false, false });
+        new LeapFrogJoin(new Operator[] { orderR, orderS, orderT }, fieldMap, outputMap, outputColumnNames);
     join.open(null);
     TupleBatch tb;
     TupleBatchBuffer batches = new TupleBatchBuffer(outputSchema);
@@ -256,8 +253,7 @@ public class LeapFrogJoinTest {
     final ImmutableList<String> outputColumnNames = ImmutableList.of("x");
     final Schema outputSchema = new Schema(ImmutableList.of(Type.INT_TYPE), outputColumnNames);
     LeapFrogJoin join =
-        new LeapFrogJoin(new Operator[] { orderA, orderB, orderC }, fieldMap, outputMap, outputColumnNames,
-            new boolean[] { false, false, true });
+        new LeapFrogJoin(new Operator[] { orderA, orderB, orderC }, fieldMap, outputMap, outputColumnNames);
     join.open(null);
     TupleBatch tb;
     TupleBatchBuffer batches = new TupleBatchBuffer(outputSchema);
@@ -296,8 +292,7 @@ public class LeapFrogJoinTest {
     final ImmutableList<String> outputColumnNames = ImmutableList.of("k");
     final Schema outputSchema = new Schema(ImmutableList.of(Type.LONG_TYPE), outputColumnNames);
     LeapFrogJoin join =
-        new LeapFrogJoin(new Operator[] { orderO, orderP, orderQ }, fieldMap, outputMap, outputColumnNames,
-            new boolean[] { false, false, false });
+        new LeapFrogJoin(new Operator[] { orderO, orderP, orderQ }, fieldMap, outputMap, outputColumnNames);
     join.open(TestEnvVars.get());
     TupleBatch tb;
     TupleBatchBuffer batches = new TupleBatchBuffer(outputSchema);


### PR DESCRIPTION
Add join variable order optimization logic inside `LeapFrogJoin`:
- [ ] get histogram like information when pulling tuples.
- [ ] put sort inside `LeapFrogJoin`, since the variable order is decided dynamically.
- [x] remove `indexOnFirst`, too few performance improvement (less 1%), conflicts with dynamic variable ordering
