### PR TITLE
DatasetResource: use default toString() for setting attachment filename

### DIFF
--- a/src/edu/washington/escience/myria/api/DatasetResource.java
+++ b/src/edu/washington/escience/myria/api/DatasetResource.java
@@ -189,8 +189,7 @@ public final class DatasetResource {
         writer = new CsvTupleWriter('\t', writerOutput);
       }
       ContentDisposition contentDisposition =
-          ContentDisposition.type("attachment").fileName(
-              relationKey.toString(MyriaConstants.STORAGE_SYSTEM_SQLITE) + '.' + validFormat).build();
+          ContentDisposition.type("attachment").fileName(relationKey.toString() + '.' + validFormat).build();
 
       response.header("Content-Disposition", contentDisposition);
       response.type(MediaType.APPLICATION_OCTET_STREAM);


### PR DESCRIPTION
Fix uwescience/myria-web#190
