### PR TITLE
Deterministic producer

### DIFF
--- a/src/edu/washington/escience/myria/api/encoding/BroadcastConsumerEncoding.java
+++ b/src/edu/washington/escience/myria/api/encoding/BroadcastConsumerEncoding.java
@@ -14,7 +14,7 @@ public class BroadcastConsumerEncoding extends AbstractConsumerEncoding<GenericS
   @Override
   public GenericShuffleConsumer construct(ConstructArgs args) {
     return new GenericShuffleConsumer(null, MyriaUtils.getSingleElement(getRealOperatorIds()), MyriaUtils
-        .integerCollectionToIntArray(getRealWorkerIds()));
+        .integerSetToIntArray(getRealWorkerIds()));
   }
 
 }

--- a/src/edu/washington/escience/myria/api/encoding/BroadcastProducerEncoding.java
+++ b/src/edu/washington/escience/myria/api/encoding/BroadcastProducerEncoding.java
@@ -21,7 +21,7 @@ public class BroadcastProducerEncoding extends AbstractProducerEncoding<GenericS
     }
     cellPartition[0] = allCells;
     return new GenericShuffleProducer(null, MyriaUtils.getSingleElement(getRealOperatorIds()), cellPartition,
-        MyriaUtils.integerCollectionToIntArray(getRealWorkerIds()), new FixValuePartitionFunction(0));
+        MyriaUtils.integerSetToIntArray(getRealWorkerIds()), new FixValuePartitionFunction(0));
   }
 
 }

--- a/src/edu/washington/escience/myria/api/encoding/CollectConsumerEncoding.java
+++ b/src/edu/washington/escience/myria/api/encoding/CollectConsumerEncoding.java
@@ -9,7 +9,7 @@ public class CollectConsumerEncoding extends AbstractConsumerEncoding<CollectCon
   @Override
   public CollectConsumer construct(ConstructArgs args) {
     return new CollectConsumer(null, MyriaUtils.getSingleElement(getRealOperatorIds()), MyriaUtils
-        .integerCollectionToIntArray(getRealWorkerIds()));
+        .integerSetToIntArray(getRealWorkerIds()));
   }
 
 }

--- a/src/edu/washington/escience/myria/api/encoding/ConsumerEncoding.java
+++ b/src/edu/washington/escience/myria/api/encoding/ConsumerEncoding.java
@@ -10,7 +10,7 @@ public class ConsumerEncoding extends AbstractConsumerEncoding<Consumer> {
   @Override
   public Consumer construct(ConstructArgs args) {
     return new Consumer(null, MyriaUtils.getSingleElement(getRealOperatorIds()), MyriaUtils
-        .integerCollectionToIntArray(getRealWorkerIds()));
+        .integerSetToIntArray(getRealWorkerIds()));
   }
 
 }

--- a/src/edu/washington/escience/myria/api/encoding/EOSControllerEncoding.java
+++ b/src/edu/washington/escience/myria/api/encoding/EOSControllerEncoding.java
@@ -13,7 +13,7 @@ public class EOSControllerEncoding extends AbstractProducerEncoding<EOSControlle
   public EOSController construct(ConstructArgs args) {
     List<ExchangePairID> ids = getRealOperatorIds();
     return new EOSController(null, ids.toArray(new ExchangePairID[ids.size()]), MyriaUtils
-        .integerCollectionToIntArray(getRealWorkerIds()));
+        .integerSetToIntArray(getRealWorkerIds()));
   }
 
 }

--- a/src/edu/washington/escience/myria/api/encoding/HyperShuffleConsumerEncoding.java
+++ b/src/edu/washington/escience/myria/api/encoding/HyperShuffleConsumerEncoding.java
@@ -13,6 +13,6 @@ public class HyperShuffleConsumerEncoding extends AbstractConsumerEncoding<Gener
   @Override
   public GenericShuffleConsumer construct(ConstructArgs args) {
     return new GenericShuffleConsumer(null, MyriaUtils.getSingleElement(getRealOperatorIds()), MyriaUtils
-        .integerCollectionToIntArray(getRealWorkerIds()));
+        .integerSetToIntArray(getRealWorkerIds()));
   }
 }

--- a/src/edu/washington/escience/myria/api/encoding/HyperShuffleProducerEncoding.java
+++ b/src/edu/washington/escience/myria/api/encoding/HyperShuffleProducerEncoding.java
@@ -49,7 +49,7 @@ public class HyperShuffleProducerEncoding extends AbstractProducerEncoding<Gener
         new MFMDHashPartitionFunction(cellPartition.length, hyperCubeDimensions, hashedColumns, mappedHCDimensions);
 
     return new GenericShuffleProducer(null, MyriaUtils.getSingleElement(getRealOperatorIds()), cellPartition,
-        MyriaUtils.integerCollectionToIntArray(args.getServer().getRandomWorkers(numCells)), pf);
+        MyriaUtils.integerSetToIntArray(args.getServer().getRandomWorkers(numCells)), pf);
   }
 
   @Override

--- a/src/edu/washington/escience/myria/api/encoding/ShuffleConsumerEncoding.java
+++ b/src/edu/washington/escience/myria/api/encoding/ShuffleConsumerEncoding.java
@@ -13,6 +13,6 @@ public class ShuffleConsumerEncoding extends AbstractConsumerEncoding<GenericShu
   @Override
   public GenericShuffleConsumer construct(ConstructArgs args) {
     return new GenericShuffleConsumer(null, MyriaUtils.getSingleElement(getRealOperatorIds()), MyriaUtils
-        .integerCollectionToIntArray(getRealWorkerIds()));
+        .integerSetToIntArray(getRealWorkerIds()));
   }
 }

--- a/src/edu/washington/escience/myria/api/encoding/ShuffleProducerEncoding.java
+++ b/src/edu/washington/escience/myria/api/encoding/ShuffleProducerEncoding.java
@@ -22,7 +22,7 @@ public class ShuffleProducerEncoding extends AbstractProducerEncoding<GenericShu
     argPf.setNumPartitions(workerIds.size());
     GenericShuffleProducer producer =
         new GenericShuffleProducer(null, MyriaUtils.getSingleElement(getRealOperatorIds()), MyriaUtils
-            .integerCollectionToIntArray(workerIds), argPf);
+            .integerSetToIntArray(workerIds), argPf);
     if (argBufferStateType != null) {
       if (argBufferStateType instanceof KeepMinValueStateEncoding) {
         producer.setBackupBufferAsMin(((KeepMinValueStateEncoding) argBufferStateType).keyColIndices,

--- a/src/edu/washington/escience/myria/parallel/Server.java
+++ b/src/edu/washington/escience/myria/parallel/Server.java
@@ -1193,7 +1193,7 @@ public final class Server {
       actualWorkers = getAliveWorkers();
     }
     Preconditions.checkArgument(actualWorkers.size() > 0, "Must use > 0 workers");
-    int[] workersArray = MyriaUtils.integerCollectionToIntArray(actualWorkers);
+    int[] workersArray = MyriaUtils.integerSetToIntArray(actualWorkers);
 
     /* The master plan: send the tuples out. */
     ExchangePairID scatterId = ExchangePairID.newID();

--- a/src/edu/washington/escience/myria/util/MyriaUtils.java
+++ b/src/edu/washington/escience/myria/util/MyriaUtils.java
@@ -1,10 +1,10 @@
 package edu.washington.escience.myria.util;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.SortedSet;
 import java.util.TreeSet;
 
 import org.joda.time.DateTime;
@@ -58,10 +58,16 @@ public final class MyriaUtils {
    * @param input the collection of integers.
    * @return an int[] containing the given integers.
    */
-  public static int[] integerCollectionToIntArray(final Collection<Integer> input) {
+  public static int[] integerSetToIntArray(final Set<Integer> input) {
+    SortedSet<Integer> set;
+    if (input instanceof SortedSet) {
+      set = (SortedSet<Integer>) input;
+    } else {
+      set = new TreeSet<>(input);
+    }
     int[] output = new int[input.size()];
     int i = 0;
-    for (int value : new TreeSet<>(input)) {
+    for (int value : set) {
       output[i] = value;
       ++i;
     }


### PR DESCRIPTION
When we had redundant shuffles (i.e., hashing on the same field as we are already partitioned on), we were not keeping data on the same machine. What was happening is that the order of workers was not deterministic, so the same partition index might be mapped to different workers for different destination fragments. Making this order deterministic has two benefits:
1. performance: we use the in-process link instead of the network and the queuing issues associated with that.
2. correctness: though Raco does not do this yet, it seems possible (I have not demonstrated such a case) that if raco elided a shuffle because a relation was already "hashed the right way" we might have ended up joining different partitions. No existing plan that could have been run actually suffered from this effect.
