### PR TITLE
api: change JSON mediatype to include charset

### DIFF
--- a/src/edu/washington/escience/myria/api/DatasetResource.java
+++ b/src/edu/washington/escience/myria/api/DatasetResource.java
@@ -61,7 +61,7 @@ import edu.washington.escience.myria.storage.TupleBatch;
  * 
  */
 @Consumes(MediaType.APPLICATION_JSON)
-@Produces(MediaType.APPLICATION_JSON)
+@Produces(MyriaApiConstants.JSON_UTF_8)
 @Path("/dataset")
 @Api(value = "/dataset", description = "Operations on datasets")
 public final class DatasetResource {
@@ -148,7 +148,7 @@ public final class DatasetResource {
    * @throws DbException if there is an error in the database.
    */
   @GET
-  @Produces({ MediaType.APPLICATION_OCTET_STREAM, MediaType.APPLICATION_JSON })
+  @Produces({ MediaType.APPLICATION_OCTET_STREAM, MyriaApiConstants.JSON_UTF_8 })
   @Path("/user-{userName}/program-{programName}/relation-{relationName}/data")
   public Response getDatasetData(@PathParam("userName") final String userName,
       @PathParam("programName") final String programName, @PathParam("relationName") final String relationName,
@@ -196,7 +196,7 @@ public final class DatasetResource {
       response.type(MediaType.APPLICATION_OCTET_STREAM);
     } else if (validFormat.equals("json")) {
       /* JSON: set application/json. */
-      response.type(MediaType.APPLICATION_JSON);
+      response.type(MyriaApiConstants.JSON_UTF_8);
       writer = new JsonTupleWriter(writerOutput);
     } else {
       /* Should not be possible to get here. */
@@ -217,7 +217,7 @@ public final class DatasetResource {
    * @throws DbException if there is an error in the database.
    */
   @GET
-  @Produces({ MediaType.APPLICATION_OCTET_STREAM, MediaType.APPLICATION_JSON })
+  @Produces({ MediaType.APPLICATION_OCTET_STREAM, MyriaApiConstants.JSON_UTF_8 })
   @Path("/download_test")
   public Response getQueryData(@QueryParam("num_tb") final int numTB, @QueryParam("format") final String format)
       throws DbException {
@@ -260,7 +260,7 @@ public final class DatasetResource {
       response.type(MediaType.APPLICATION_OCTET_STREAM);
     } else if (validFormat.equals("json")) {
       /* JSON: set application/json. */
-      response.type(MediaType.APPLICATION_JSON);
+      response.type(MyriaApiConstants.JSON_UTF_8);
       writer = new JsonTupleWriter(writerOutput);
     } else {
       /* Should not be possible to get here. */
@@ -287,7 +287,6 @@ public final class DatasetResource {
    */
   @PUT
   @Consumes(MediaType.APPLICATION_OCTET_STREAM)
-  @Produces(MediaType.APPLICATION_JSON)
   @Path("/user-{userName}/program-{programName}/relation-{relationName}/data")
   public Response replaceDataset(final InputStream is, @PathParam("userName") final String userName,
       @PathParam("programName") final String programName, @PathParam("relationName") final String relationName,

--- a/src/edu/washington/escience/myria/api/MasterResource.java
+++ b/src/edu/washington/escience/myria/api/MasterResource.java
@@ -4,7 +4,6 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import edu.washington.escience.myria.api.encoding.VersionEncoding;
@@ -53,7 +52,7 @@ public final class MasterResource {
    * @return a {@link VersionEncoding}.
    */
   @GET
-  @Produces(MediaType.APPLICATION_JSON)
+  @Produces(MyriaApiConstants.JSON_UTF_8)
   public Response getVersion() {
     return Response.ok(new VersionEncoding()).build();
   }

--- a/src/edu/washington/escience/myria/api/MyriaApiConstants.java
+++ b/src/edu/washington/escience/myria/api/MyriaApiConstants.java
@@ -3,7 +3,6 @@ package edu.washington.escience.myria.api;
 /**
  * This class holds constants used in the Myria API server.
  * 
- * 
  */
 public final class MyriaApiConstants {
   /** This class just holds constants. */
@@ -20,6 +19,8 @@ public final class MyriaApiConstants {
   public static final String MYRIA_API_SSL_KEYSTORE = "myria.master_api_server.ssl.keystore_path";
   /** The password to the SSL Keystore. */
   public static final String MYRIA_API_SSL_KEYSTORE_PASSWORD = "myria.master_api_server.ssl.keystore_password";
+  /** JSON, UTF-8 is the default response type when serializing JSON. */
+  public static final String JSON_UTF_8 = "application/json; charset=UTF-8";
 
   /** The default number of results returned in a large query. */
   public static final Long MYRIA_API_DEFAULT_NUM_RESULTS = 10L;

--- a/src/edu/washington/escience/myria/api/MyriaJsonMapperProvider.java
+++ b/src/edu/washington/escience/myria/api/MyriaJsonMapperProvider.java
@@ -1,7 +1,6 @@
 package edu.washington.escience.myria.api;
 
 import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.ext.Provider;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
@@ -20,7 +19,7 @@ import com.fasterxml.jackson.jaxrs.json.JacksonJaxbJsonProvider;
  * 
  */
 @Provider
-@Produces(MediaType.APPLICATION_JSON)
+@Produces(MyriaApiConstants.JSON_UTF_8)
 public class MyriaJsonMapperProvider extends JacksonJaxbJsonProvider {
   /** Only create this object once, and share it among instances. */
   private static final ObjectMapper MAPPER = newMapper();

--- a/src/edu/washington/escience/myria/api/QueryResource.java
+++ b/src/edu/washington/escience/myria/api/QueryResource.java
@@ -35,7 +35,7 @@ import edu.washington.escience.myria.parallel.Server;
  * 
  */
 @Consumes(MediaType.APPLICATION_JSON)
-@Produces(MediaType.APPLICATION_JSON)
+@Produces(MyriaApiConstants.JSON_UTF_8)
 @Path("/query")
 public final class QueryResource {
   /** The Myria server running on the master. */

--- a/src/edu/washington/escience/myria/api/WorkerCollection.java
+++ b/src/edu/washington/escience/myria/api/WorkerCollection.java
@@ -9,7 +9,6 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
@@ -21,7 +20,7 @@ import edu.washington.escience.myria.parallel.SocketInfo;
  * 
  */
 @Path("/workers")
-@Produces(MediaType.APPLICATION_JSON)
+@Produces(MyriaApiConstants.JSON_UTF_8)
 public final class WorkerCollection {
   /** The Myria server running on the master. */
   @Context


### PR DESCRIPTION
Fix #639.

I don't like the idea of adding `; charset=UTF_8` to every response media type as the other suggestions were, and there are relatively few places we actually use JSON right now that adding a constant and replacing its use seemed somewhat reasonable.
