### PR TITLE
travis: upgrade infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,9 @@ before_install:
 - export TERM=dumb
 after_success:
 - ./gradlew jacocoTestReport coveralls
+
 sudo: false
 
-
-# Caching is only available for private repos
-# .. http://docs.travis-ci.com/user/caching/
-#cache:
-#  directories:
-#  - $HOME/.gradle
+cache:
+  directories:
+  - $HOME/.gradle


### PR DESCRIPTION
1) new containers are faster. Enabled with `with sudo: false` (we don't use sudo)
2) new containers support caching. Re-enabled.

see: http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/
