### PR TITLE
Jwang add join pull order encoding

### DIFF
--- a/src/edu/washington/escience/myria/api/MyriaExceptionMapper.java
+++ b/src/edu/washington/escience/myria/api/MyriaExceptionMapper.java
@@ -82,8 +82,7 @@ public final class MyriaExceptionMapper implements ExceptionMapper<Throwable> {
       return ((MyriaApiException) cause).getResponse();
     }
     ResponseBuilder ret = Response.status(status);
-    if (status.equals(Status.INTERNAL_SERVER_ERROR) || status.equals(Status.BAD_REQUEST) || cause.getMessage() == null
-        || cause.getMessage().length() == 0) {
+    if (status.equals(Status.INTERNAL_SERVER_ERROR) || cause.getMessage() == null || cause.getMessage().length() == 0) {
       ret.entity(ErrorUtils.getStackTrace(cause));
     } else {
       ret.entity(cause.getMessage());

--- a/src/edu/washington/escience/myria/api/MyriaExceptionMapper.java
+++ b/src/edu/washington/escience/myria/api/MyriaExceptionMapper.java
@@ -82,7 +82,8 @@ public final class MyriaExceptionMapper implements ExceptionMapper<Throwable> {
       return ((MyriaApiException) cause).getResponse();
     }
     ResponseBuilder ret = Response.status(status);
-    if (status.equals(Status.INTERNAL_SERVER_ERROR) || cause.getMessage() == null || cause.getMessage().length() == 0) {
+    if (status.equals(Status.INTERNAL_SERVER_ERROR) || status.equals(Status.BAD_REQUEST) || cause.getMessage() == null
+        || cause.getMessage().length() == 0) {
       ret.entity(ErrorUtils.getStackTrace(cause));
     } else {
       ret.entity(cause.getMessage());

--- a/src/edu/washington/escience/myria/api/encoding/IDBControllerEncoding.java
+++ b/src/edu/washington/escience/myria/api/encoding/IDBControllerEncoding.java
@@ -26,29 +26,29 @@ public class IDBControllerEncoding extends OperatorEncoding<IDBController> {
 
   public Boolean sync;
 
-  private ExchangePairID realControllerOperatorId;
-  public Integer realControllerWorkerId;
+  private ExchangePairID realEosControllerOperatorId;
+  public Integer realEosControllerWorkerId;
 
   @Required
   public StreamingStateEncoding<?> argState;
 
   @Override
-  public IDBController construct(ConstructArgs args) {
-    return new IDBController(argSelfIdbId, realControllerOperatorId, realControllerWorkerId, null, null, null, argState
-        .construct(), MoreObjects.firstNonNull(sync, Boolean.FALSE));
+  public IDBController construct(final ConstructArgs args) {
+    return new IDBController(argSelfIdbId, realEosControllerOperatorId, realEosControllerWorkerId, null, null, null,
+        argState.construct(), MoreObjects.firstNonNull(sync, Boolean.FALSE));
   }
 
   @Override
-  public void connect(Operator current, Map<Integer, Operator> operators) {
+  public void connect(final Operator current, final Map<Integer, Operator> operators) {
     current.setChildren(new Operator[] {
         operators.get(argInitialInput), operators.get(argIterationInput), operators.get(argEosControllerInput) });
   }
 
-  protected void setRealControllerOperatorID(final ExchangePairID realControllerOperatorId) {
-    this.realControllerOperatorId = realControllerOperatorId;
+  protected void setRealEosControllerOperatorID(final ExchangePairID realEosControllerOperatorId) {
+    this.realEosControllerOperatorId = realEosControllerOperatorId;
   }
 
-  protected ExchangePairID getRealControllerOperatorID() {
-    return realControllerOperatorId;
+  protected ExchangePairID getRealEosControllerOperatorID() {
+    return realEosControllerOperatorId;
   }
 }

--- a/src/edu/washington/escience/myria/api/encoding/InMemoryOrderByEncoding.java
+++ b/src/edu/washington/escience/myria/api/encoding/InMemoryOrderByEncoding.java
@@ -14,13 +14,12 @@ public class InMemoryOrderByEncoding extends UnaryOperatorEncoding<InMemoryOrder
   public boolean[] argAscending;
 
   @Override
-  public InMemoryOrderBy construct(ConstructArgs args) throws MyriaApiException {
+  public InMemoryOrderBy construct(final ConstructArgs args) throws MyriaApiException {
     return new InMemoryOrderBy(null, argSortColumns, argAscending);
   }
 
   @Override
   protected void validateExtra() {
-
     if (argSortColumns.length != argAscending.length) {
       throw new MyriaApiException(Status.BAD_REQUEST, "sort columns number should be equal to ascending orders number!");
     }

--- a/src/edu/washington/escience/myria/api/encoding/MyriaApiEncoding.java
+++ b/src/edu/washington/escience/myria/api/encoding/MyriaApiEncoding.java
@@ -9,7 +9,7 @@ import javax.ws.rs.core.Response.Status;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.base.Joiner;
-import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
 
 import edu.washington.escience.myria.api.MyriaApiException;
 
@@ -21,16 +21,16 @@ import edu.washington.escience.myria.api.MyriaApiException;
  */
 public abstract class MyriaApiEncoding {
   /**
-   * @return the list of names of required fields.
+   * @return a list of required fields.
    */
   @JsonIgnore
-  private final List<String> getRequiredFields() {
+  private final List<Field> getRequiredFields() {
     Field[] fs = this.getClass().getFields();
-    List<String> requiredFields = new LinkedList<>();
+    List<Field> requiredFields = new LinkedList<>();
     for (Field f : fs) {
       Annotation a = f.getAnnotation(Required.class);
       if (a != null) {
-        requiredFields.add(f.getName());
+        requiredFields.add(f);
       }
     }
     return requiredFields;
@@ -44,22 +44,21 @@ public abstract class MyriaApiEncoding {
    * @throws MyriaApiException if the validation checks fail.
    */
   public final void validate() throws MyriaApiException {
-    /* Fetch the list of required fields. */
-    final List<String> fields = getRequiredFields();
-    String current = "";
+    final List<String> missing = Lists.newLinkedList();
     /* Check using Java reflection to see that every field is there. */
     try {
-      for (final String f : fields) {
-        current = f;
-        Preconditions.checkNotNull(getClass().getField(f).get(this));
+      for (final Field f : getRequiredFields()) {
+        if (null == f.get(this)) {
+          missing.add(f.getName());
+        }
       }
-    } catch (NoSuchFieldException | IllegalAccessException e) {
+    } catch (IllegalAccessException e) {
       throw new MyriaApiException(Status.INTERNAL_SERVER_ERROR, e);
-    } catch (final NullPointerException e1) {
+    }
+    if (!missing.isEmpty()) {
       /* Some field is missing; throw a 400 (BAD REQUEST) exception with the list of required fields. */
-      final StringBuilder sb = new StringBuilder(getClass().getName()).append(" has required fields: ");
-      sb.append(Joiner.on(", ").join(fields));
-      sb.append(". Missing ").append(current);
+      final StringBuilder sb = new StringBuilder(getClass().getName()).append(" is missing required fields: ");
+      sb.append(Joiner.on(", ").join(missing)).append(".\n");
       throw new MyriaApiException(Status.BAD_REQUEST, sb.toString());
     }
     validateExtra();

--- a/src/edu/washington/escience/myria/api/encoding/MyriaApiEncoding.java
+++ b/src/edu/washington/escience/myria/api/encoding/MyriaApiEncoding.java
@@ -8,6 +8,7 @@ import java.util.List;
 import javax.ws.rs.core.Response.Status;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 
 import edu.washington.escience.myria.api.MyriaApiException;
@@ -57,16 +58,8 @@ public abstract class MyriaApiEncoding {
     } catch (final NullPointerException e1) {
       /* Some field is missing; throw a 400 (BAD REQUEST) exception with the list of required fields. */
       final StringBuilder sb = new StringBuilder(getClass().getName()).append(" has required fields: ");
-      boolean first = true;
-      for (final String f : fields) {
-        if (!first) {
-          sb.append(", ");
-        }
-        first = false;
-        sb.append(f);
-      }
-      sb.append(". Error on ");
-      sb.append(current);
+      sb.append(Joiner.on(", ").join(fields));
+      sb.append(". Missing ").append(current);
       throw new MyriaApiException(Status.BAD_REQUEST, sb.toString());
     }
     validateExtra();

--- a/src/edu/washington/escience/myria/api/encoding/QueryConstruct.java
+++ b/src/edu/washington/escience/myria/api/encoding/QueryConstruct.java
@@ -239,7 +239,7 @@ public class QueryConstruct {
     for (IDBControllerEncoding idbController : idbControllers) {
       List<ExchangePairID> ids = producerOutputChannels.get(idbController.opId);
       Preconditions.checkNotNull(ids, "Can't find channel IDs for IDBController opId=%s", idbController.opId);
-      Preconditions.checkArgument(ids.size() == 1, "IDBController opId=%s has multiple output channels",
+      Preconditions.checkArgument(ids.size() == 1, "IDBController opId=%s has zero or multiple output channels",
           idbController.opId);
       idbController.setRealEosControllerOperatorID(ids.get(0));
     }
@@ -253,7 +253,8 @@ public class QueryConstruct {
             if (exchange instanceof AbstractConsumerEncoding) {
               int argOpId = ((AbstractConsumerEncoding<?>) exchange).getArgOperatorId();
               Set<Integer> producerWorkers = producerWorkerMap.get(argOpId);
-              Preconditions.checkNotNull(producerWorkers,
+              /* Use checkArgument instead of checkNotNull to throw an IllegalArgumentException */
+              Preconditions.checkArgument(producerWorkers != null,
                   "Can't find corresponding producer for consumer opId=%s, argOperatorId: %s", operator.opId, argOpId);
               workers.addAll(producerWorkers);
             } else if (exchange instanceof AbstractProducerEncoding) {

--- a/src/edu/washington/escience/myria/api/encoding/QueryConstruct.java
+++ b/src/edu/washington/escience/myria/api/encoding/QueryConstruct.java
@@ -50,7 +50,6 @@ import edu.washington.escience.myria.parallel.RelationWriteMetadata;
 import edu.washington.escience.myria.parallel.Server;
 import edu.washington.escience.myria.parallel.SubQuery;
 import edu.washington.escience.myria.parallel.SubQueryPlan;
-import edu.washington.escience.myria.util.MyriaUtils;
 
 public class QueryConstruct {
   /** The logger for this class. */
@@ -199,7 +198,7 @@ public class QueryConstruct {
     Map<Integer, Set<Integer>> producerWorkerMap = new HashMap<Integer, Set<Integer>>();
     Map<ExchangePairID, Set<Integer>> consumerWorkerMap = new HashMap<ExchangePairID, Set<Integer>>();
     Map<Integer, List<ExchangePairID>> producerOutputChannels = new HashMap<Integer, List<ExchangePairID>>();
-    List<IDBControllerEncoding> idbInputs = new ArrayList<IDBControllerEncoding>();
+    List<IDBControllerEncoding> idbControllers = new ArrayList<IDBControllerEncoding>();
     /* Pass 1: map strings to real operator IDs, also collect producers and consumers. */
     for (PlanFragmentEncoding fragment : fragments) {
       for (OperatorEncoding<?> operator : fragment.operators) {
@@ -216,7 +215,6 @@ public class QueryConstruct {
           consumer.setRealOperatorIds(Arrays.asList(new ExchangePairID[] { channelID }));
           sourceProducerOutputChannels.add(channelID);
           consumerWorkerMap.put(channelID, ImmutableSet.<Integer> builder().addAll(fragment.workers).build());
-
         } else if (operator instanceof AbstractProducerEncoding) {
           AbstractProducerEncoding<?> producer = (AbstractProducerEncoding<?>) operator;
           List<ExchangePairID> sourceProducerOutputChannels = producerOutputChannels.get(producer.opId);
@@ -227,19 +225,23 @@ public class QueryConstruct {
           producer.setRealOperatorIds(sourceProducerOutputChannels);
           producerWorkerMap.put(producer.opId, ImmutableSet.<Integer> builder().addAll(fragment.workers).build());
         } else if (operator instanceof IDBControllerEncoding) {
-          IDBControllerEncoding idbInput = (IDBControllerEncoding) operator;
-          idbInputs.add(idbInput);
-          List<ExchangePairID> sourceProducerOutputChannels = producerOutputChannels.get(idbInput.opId);
+          IDBControllerEncoding idbController = (IDBControllerEncoding) operator;
+          idbControllers.add(idbController);
+          List<ExchangePairID> sourceProducerOutputChannels = producerOutputChannels.get(idbController.opId);
           if (sourceProducerOutputChannels == null) {
             sourceProducerOutputChannels = new ArrayList<ExchangePairID>();
-            producerOutputChannels.put(idbInput.opId, sourceProducerOutputChannels);
+            producerOutputChannels.put(idbController.opId, sourceProducerOutputChannels);
           }
-          producerWorkerMap.put(idbInput.opId, new HashSet<Integer>(fragment.workers));
+          producerWorkerMap.put(idbController.opId, new HashSet<Integer>(fragment.workers));
         }
       }
     }
-    for (IDBControllerEncoding idbInput : idbInputs) {
-      idbInput.setRealControllerOperatorID(producerOutputChannels.get(idbInput.opId).get(0));
+    for (IDBControllerEncoding idbController : idbControllers) {
+      List<ExchangePairID> ids = producerOutputChannels.get(idbController.opId);
+      Preconditions.checkNotNull(ids, "Can't find channel IDs for IDBController opId=%s", idbController.opId);
+      Preconditions.checkArgument(ids.size() == 1, "IDBController opId=%s has multiple output channels",
+          idbController.opId);
+      idbController.setRealEosControllerOperatorID(ids.get(0));
     }
     /* Pass 2: Populate the right fields in producers and consumers. */
     for (PlanFragmentEncoding fragment : fragments) {
@@ -249,16 +251,16 @@ public class QueryConstruct {
           ImmutableSet.Builder<Integer> workers = ImmutableSet.builder();
           for (ExchangePairID id : exchange.getRealOperatorIds()) {
             if (exchange instanceof AbstractConsumerEncoding) {
-              try {
-                workers.addAll(producerWorkerMap.get(((AbstractConsumerEncoding<?>) exchange).getArgOperatorId()));
-              } catch (NullPointerException ee) {
-                LOGGER.error("Consumer: {}", ((AbstractConsumerEncoding<?>) exchange).opId);
-                LOGGER.error("Producer: {}", ((AbstractConsumerEncoding<?>) exchange).argOperatorId);
-                LOGGER.error("producerWorkerMap: {}", producerWorkerMap);
-                throw ee;
-              }
+              int argOpId = ((AbstractConsumerEncoding<?>) exchange).getArgOperatorId();
+              Set<Integer> producerWorkers = producerWorkerMap.get(argOpId);
+              Preconditions.checkNotNull(producerWorkers,
+                  "Can't find corresponding producer for consumer opId=%s, argOperatorId: %s", operator.opId, argOpId);
+              workers.addAll(producerWorkers);
             } else if (exchange instanceof AbstractProducerEncoding) {
-              workers.addAll(consumerWorkerMap.get(id));
+              Set<Integer> consumerWorkers = consumerWorkerMap.get(id);
+              Preconditions.checkNotNull(consumerWorkers, "Can't find corresponding consumer for producer opId=%s",
+                  operator.opId);
+              workers.addAll(consumerWorkers);
             } else {
               throw new IllegalStateException("ExchangeEncoding " + operator.getClass().getSimpleName()
                   + " is not a Producer or Consumer encoding");
@@ -267,8 +269,15 @@ public class QueryConstruct {
           exchange.setRealWorkerIds(workers.build());
         } else if (operator instanceof IDBControllerEncoding) {
           IDBControllerEncoding idbController = (IDBControllerEncoding) operator;
-          idbController.realControllerWorkerId =
-              MyriaUtils.getSingleElement(consumerWorkerMap.get(idbController.getRealControllerOperatorID()));
+          ExchangePairID id = idbController.getRealEosControllerOperatorID();
+          Preconditions.checkNotNull(id, "Can't get real EOSController operator ID for IDBController opId=%s",
+              operator.opId);
+          Set<Integer> consumerWorkers = consumerWorkerMap.get(id);
+          Preconditions.checkNotNull(consumerWorkers, "Can't find corresponding consumers for IDBController opId=%s",
+              operator.opId);
+          Preconditions.checkArgument(consumerWorkers.size() == 1,
+              "The consumer corresponds to IDBController opId=%s lives on more than one worker", operator.opId);
+          idbController.realEosControllerWorkerId = consumerWorkers.iterator().next();
         }
       }
     }

--- a/src/edu/washington/escience/myria/api/encoding/SymmetricHashJoinEncoding.java
+++ b/src/edu/washington/escience/myria/api/encoding/SymmetricHashJoinEncoding.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import edu.washington.escience.myria.api.encoding.QueryConstruct.ConstructArgs;
 import edu.washington.escience.myria.operator.SymmetricHashJoin;
+import edu.washington.escience.myria.operator.SymmetricHashJoin.JoinPullOrder;
 
 public class SymmetricHashJoinEncoding extends BinaryOperatorEncoding<SymmetricHashJoin> {
 
@@ -18,11 +19,15 @@ public class SymmetricHashJoinEncoding extends BinaryOperatorEncoding<SymmetricH
   public int[] argSelect2;
   public boolean argSetSemanticsLeft = false;
   public boolean argSetSemanticsRight = false;
+  public JoinPullOrder argOrder = JoinPullOrder.ALTER;
 
   @Override
-  public SymmetricHashJoin construct(ConstructArgs args) {
-    return new SymmetricHashJoin(argColumnNames, null, null, argColumns1, argColumns2, argSelect1, argSelect2,
-        argSetSemanticsLeft, argSetSemanticsRight);
+  public SymmetricHashJoin construct(final ConstructArgs args) {
+    SymmetricHashJoin join =
+        new SymmetricHashJoin(argColumnNames, null, null, argColumns1, argColumns2, argSelect1, argSelect2,
+            argSetSemanticsLeft, argSetSemanticsRight);
+    join.setPullOrder(argOrder);
+    return join;
   }
 
 }

--- a/src/edu/washington/escience/myria/api/encoding/plan/DoWhileEncoding.java
+++ b/src/edu/washington/escience/myria/api/encoding/plan/DoWhileEncoding.java
@@ -31,7 +31,7 @@ public class DoWhileEncoding extends SubPlanEncoding {
     Preconditions.checkArgument(body.size() > 0, "DoWhile cannot be empty");
     int i = 0;
     for (SubPlanEncoding p : body) {
-      Preconditions.checkNotNull(p, "body plan %s/%s", i, body.size());
+      Preconditions.checkNotNull(p, "body plan %s/%s is null", i, body.size());
       p.validate();
       ++i;
     }

--- a/src/edu/washington/escience/myria/api/encoding/plan/SequenceEncoding.java
+++ b/src/edu/washington/escience/myria/api/encoding/plan/SequenceEncoding.java
@@ -29,7 +29,7 @@ public class SequenceEncoding extends SubPlanEncoding {
     Preconditions.checkArgument(plans.size() > 0, "Sequence cannot be empty");
     int i = 0;
     for (SubPlanEncoding p : plans) {
-      Preconditions.checkNotNull(p, "plan %s/%s", i, plans.size());
+      Preconditions.checkNotNull(p, "plan %s/%s is null", i, plans.size());
       p.validate();
       ++i;
     }

--- a/src/edu/washington/escience/myria/api/encoding/plan/SubQueryEncoding.java
+++ b/src/edu/washington/escience/myria/api/encoding/plan/SubQueryEncoding.java
@@ -31,7 +31,7 @@ public class SubQueryEncoding extends SubPlanEncoding {
   public void validateExtra() {
     int i = 0;
     for (PlanFragmentEncoding f : fragments) {
-      Preconditions.checkNotNull(f, "fragment %s of %s", i, fragments.size());
+      Preconditions.checkNotNull(f, "fragment %s of %s is null", i, fragments.size());
       f.validate();
       ++i;
     }

--- a/src/edu/washington/escience/myria/operator/BinaryOperator.java
+++ b/src/edu/washington/escience/myria/operator/BinaryOperator.java
@@ -49,11 +49,12 @@ public abstract class BinaryOperator extends Operator {
   @Override
   public final void setChildren(final Operator[] children) {
     Preconditions.checkArgument(left == null && right == null,
-        "called setChildren(), but children have already been set");
-    Preconditions.checkNotNull(children);
-    Preconditions.checkArgument(children.length == 2, "setChildren() must be called with an array of length 2");
-    Preconditions.checkNotNull(children[0]);
-    Preconditions.checkNotNull(children[1]);
+        "Operator opId=%s called setChildren(), but children have already been set", opId);
+    Preconditions.checkNotNull(children, "Operator opId=%s has null children", opId);
+    Preconditions.checkArgument(children.length == 2,
+        "Operator opId=%s setChildren() must be called with an array of length 2", opId);
+    Preconditions.checkNotNull(children[0], "Operator opId=%s has its first child to be null", opId);
+    Preconditions.checkNotNull(children[1], "Operator opId=%s has its second child to be null", opId);
     left = children[0];
     right = children[1];
     /* Generate the Schema now as a way of sanity-checking the constructor arguments. */

--- a/src/edu/washington/escience/myria/operator/Operator.java
+++ b/src/edu/washington/escience/myria/operator/Operator.java
@@ -52,7 +52,7 @@ public abstract class Operator implements Serializable {
   /**
    * The unique operator id.
    */
-  private Integer opId;
+  protected Integer opId;
 
   /**
    * A bit denoting whether the operator is open (initialized).

--- a/src/edu/washington/escience/myria/operator/RootOperator.java
+++ b/src/edu/washington/escience/myria/operator/RootOperator.java
@@ -146,7 +146,7 @@ public abstract class RootOperator extends Operator {
     if (children.length != 1) {
       throw new IllegalArgumentException("a root operator must have exactly one child");
     }
-    Preconditions.checkNotNull(children[0]);
+    Preconditions.checkNotNull(children[0], "RootOperator opId=%s has a null child", opId);
     child = children[0];
   }
 

--- a/src/edu/washington/escience/myria/operator/UnaryOperator.java
+++ b/src/edu/washington/escience/myria/operator/UnaryOperator.java
@@ -47,10 +47,12 @@ public abstract class UnaryOperator extends Operator {
 
   @Override
   public final void setChildren(final Operator[] children) {
-    Preconditions.checkArgument(child == null, "called setChildren(), but children have already been set");
-    Preconditions.checkNotNull(children);
-    Preconditions.checkArgument(children.length == 1, "setChildren() must be called with an array of length 1");
-    Preconditions.checkNotNull(children[0]);
+    Preconditions.checkArgument(child == null,
+        "Operator opid=%s called setChildren(), but children have already been set", opId);
+    Preconditions.checkNotNull(children, "Unary operator opId=%s has null children", opId);
+    Preconditions.checkArgument(children.length == 1,
+        "Operator opId=%s setChildren() must be called with an array of length 1", opId);
+    Preconditions.checkNotNull(children[0], "Unary operator opId=%s has its child to be null", opId);
     child = children[0];
     /* Trigger Schema updating. */
     getSchema();


### PR DESCRIPTION
By default it's ALTER if not specified.
ALTER: pull both children alternatively.
LEFT: for each fetchNextReady(), start from the left child, and stick to pulling the left child until no data, then switch the the right child.
RIGHT: same as LEFT.