### PR TITLE
RootOperator: return the coalesced batch

### DIFF
--- a/src/edu/washington/escience/myria/operator/RootOperator.java
+++ b/src/edu/washington/escience/myria/operator/RootOperator.java
@@ -119,7 +119,8 @@ public abstract class RootOperator extends Operator {
     TupleBatch tb = null;
     tb = child.nextReady();
     if (tb != null) {
-      consumeTuples(getCoalesced(tb));
+      tb = getCoalesced(tb);
+      consumeTuples(tb);
     } else if (child.eoi()) {
       childEOI();
     } else if (child.eos()) {


### PR DESCRIPTION
If coalescing is enabled, the tuple batch returned by RootOperator may
have been incorrect because we returned the original, not coalesced,
batch.

Doubt this had much practical impact, but it could affect profiling results.