### PR TITLE
profiling of multi-subquery queries

### DIFF
--- a/src/edu/washington/escience/myria/MyriaConstants.java
+++ b/src/edu/washington/escience/myria/MyriaConstants.java
@@ -247,9 +247,9 @@ public final class MyriaConstants {
   /**
    * The schema of the {@link #EVENT_PROFILING_RELATION}.
    */
-  public static final Schema EVENT_PROFILING_SCHEMA = Schema.ofFields(Type.LONG_TYPE, Type.INT_TYPE, Type.INT_TYPE,
-      Type.LONG_TYPE, Type.LONG_TYPE, Type.LONG_TYPE, "queryId", "fragmentId", "opId", "startTime", "endTime",
-      "numTuples");
+  public static final Schema EVENT_PROFILING_SCHEMA = Schema.ofFields("queryId", Type.LONG_TYPE, "subQueryId",
+      Type.INT_TYPE, "fragmentId", Type.INT_TYPE, "opId", Type.INT_TYPE, "startTime", Type.LONG_TYPE, "endTime",
+      Type.LONG_TYPE, "numTuples", Type.LONG_TYPE);
 
   /**
    * The relation that stores profiling information about sent tuples.
@@ -259,8 +259,9 @@ public final class MyriaConstants {
   /**
    * The schema of the {@link #SENT_PROFILING_RELATION}.
    */
-  public static final Schema SENT_PROFILING_SCHEMA = Schema.ofFields(Type.LONG_TYPE, Type.INT_TYPE, Type.LONG_TYPE,
-      Type.LONG_TYPE, Type.INT_TYPE, "queryId", "fragmentId", "nanoTime", "numTuples", "destWorkerId");
+  public static final Schema SENT_PROFILING_SCHEMA = Schema.ofFields("queryId", Type.LONG_TYPE, "subQueryId",
+      Type.LONG_TYPE, "fragmentId", Type.INT_TYPE, "nanoTime", Type.LONG_TYPE, "numTuples", Type.LONG_TYPE,
+      "destWorkerId", Type.INT_TYPE);
 
   /**
    * The relation that stores resource profiling information.
@@ -270,9 +271,9 @@ public final class MyriaConstants {
   /**
    * The schema of the {@link #RESOURCE_PROFILING_RELATION}.
    */
-  public static final Schema RESOURCE_PROFILING_SCHEMA = Schema.ofFields(Type.LONG_TYPE, Type.INT_TYPE,
-      Type.STRING_TYPE, Type.LONG_TYPE, Type.LONG_TYPE, Type.LONG_TYPE, "timestamp", "opId", "measurement", "value",
-      "queryId", "subqueryId");
+  public static final Schema RESOURCE_PROFILING_SCHEMA = Schema.ofFields("timestamp", Type.LONG_TYPE, "opId",
+      Type.INT_TYPE, "measurement", Type.STRING_TYPE, "value", Type.LONG_TYPE, "queryId", Type.LONG_TYPE, "subqueryId",
+      Type.LONG_TYPE);
 
   /**
    * For how long cached versions of the profiling data should be valid.

--- a/src/edu/washington/escience/myria/MyriaConstants.java
+++ b/src/edu/washington/escience/myria/MyriaConstants.java
@@ -260,7 +260,7 @@ public final class MyriaConstants {
    * The schema of the {@link #SENT_PROFILING_RELATION}.
    */
   public static final Schema SENT_PROFILING_SCHEMA = Schema.ofFields("queryId", Type.LONG_TYPE, "subQueryId",
-      Type.LONG_TYPE, "fragmentId", Type.INT_TYPE, "nanoTime", Type.LONG_TYPE, "numTuples", Type.LONG_TYPE,
+      Type.INT_TYPE, "fragmentId", Type.INT_TYPE, "nanoTime", Type.LONG_TYPE, "numTuples", Type.LONG_TYPE,
       "destWorkerId", Type.INT_TYPE);
 
   /**

--- a/src/edu/washington/escience/myria/api/LogResource.java
+++ b/src/edu/washington/escience/myria/api/LogResource.java
@@ -28,6 +28,7 @@ import edu.washington.escience.myria.DbException;
 import edu.washington.escience.myria.MyriaConstants;
 import edu.washington.escience.myria.TupleWriter;
 import edu.washington.escience.myria.parallel.Server;
+import edu.washington.escience.myria.parallel.SubQueryId;
 
 /**
  * Class that handles logs.
@@ -43,7 +44,7 @@ public final class LogResource {
    * Get profiling logs of a query.
    * 
    * @param queryId query id.
-   * @param subQueryId subquery id.
+   * @param subqueryId subquery id.
    * @param fragmentId the fragment id.
    * @param start the earliest time where we need data
    * @param end the latest time
@@ -56,7 +57,7 @@ public final class LogResource {
   @GET
   @Path("profiling")
   public Response getProfileLogs(@QueryParam("queryId") final Long queryId,
-      @DefaultValue("0") @QueryParam("subQueryId") final long subQueryId,
+      @DefaultValue("0") @QueryParam("subqueryId") final long subqueryId,
       @QueryParam("fragmentId") final Long fragmentId, @QueryParam("start") final Long start,
       @QueryParam("end") final Long end, @DefaultValue("0") @QueryParam("minLength") final Long minLength,
       @DefaultValue("false") @QueryParam("onlyRootOp") final boolean onlyRootOp, @Context final Request request)
@@ -69,7 +70,7 @@ public final class LogResource {
     Preconditions.checkArgument(minLength >= 0, "MinLength has to be greater than or equal to 0");
 
     EntityTag eTag =
-        new EntityTag(Integer.toString(Joiner.on('-').join("profiling", queryId, subQueryId, fragmentId).hashCode()));
+        new EntityTag(Integer.toString(Joiner.on('-').join("profiling", queryId, subqueryId, fragmentId).hashCode()));
     Object obj = checkAndAddCache(request, eTag);
     if (obj instanceof Response) {
       return (Response) obj;
@@ -91,7 +92,8 @@ public final class LogResource {
     PipedStreamingOutput entity = new PipedStreamingOutput(input);
     response.entity(entity);
 
-    server.startLogDataStream(queryId, subQueryId, fragmentId, start, end, minLength, onlyRootOp, writer);
+    server.startLogDataStream(new SubQueryId(queryId, subqueryId), fragmentId, start, end, minLength, onlyRootOp,
+        writer);
     return response.build();
   }
 
@@ -99,7 +101,7 @@ public final class LogResource {
    * Get contribution of each operator to runtime.
    * 
    * @param queryId query id.
-   * @param subQueryId subquery id.
+   * @param subqueryId subquery id.
    * @param fragmentId the fragment id, default is all.
    * @param request the current request.
    * @return the contributions across all workers
@@ -108,14 +110,14 @@ public final class LogResource {
   @GET
   @Path("contribution")
   public Response getContributions(@QueryParam("queryId") final Long queryId,
-      @DefaultValue("0") @QueryParam("subQueryId") final long subQueryId,
+      @DefaultValue("0") @QueryParam("subqueryId") final long subqueryId,
       @DefaultValue("-1") @QueryParam("fragmentId") final Long fragmentId, @Context final Request request)
       throws DbException {
 
     Preconditions.checkArgument(queryId != null, "Missing required field queryId.");
 
     EntityTag eTag =
-        new EntityTag(Integer.toString(Joiner.on('-').join("contribution", queryId, subQueryId, fragmentId).hashCode()));
+        new EntityTag(Integer.toString(Joiner.on('-').join("contribution", queryId, subqueryId, fragmentId).hashCode()));
     Object obj = checkAndAddCache(request, eTag);
     if (obj instanceof Response) {
       return (Response) obj;
@@ -137,7 +139,7 @@ public final class LogResource {
     PipedStreamingOutput entity = new PipedStreamingOutput(input);
     response.entity(entity);
 
-    server.startContributionsStream(queryId, subQueryId, fragmentId, writer);
+    server.startContributionsStream(new SubQueryId(queryId, subqueryId), fragmentId, writer);
 
     return response.build();
   }
@@ -146,7 +148,7 @@ public final class LogResource {
    * Get information about where tuples were sent.
    * 
    * @param queryId query id.
-   * @param subQueryId subquery id.
+   * @param subqueryId subquery id.
    * @param fragmentId the fragment id. < 0 means all
    * @param request the current request.
    * @return the profiling logs of the query across all workers
@@ -155,14 +157,14 @@ public final class LogResource {
   @GET
   @Path("sent")
   public Response getSentLogs(@QueryParam("queryId") final Long queryId,
-      @DefaultValue("0") @QueryParam("subQueryId") final long subQueryId,
+      @DefaultValue("0") @QueryParam("subqueryId") final long subqueryId,
       @DefaultValue("-1") @QueryParam("fragmentId") final long fragmentId, @Context final Request request)
       throws DbException {
 
     Preconditions.checkArgument(queryId != null, "Missing required field queryId.");
 
     EntityTag eTag =
-        new EntityTag(Integer.toString(Joiner.on('-').join("sent", queryId, subQueryId, fragmentId).hashCode()));
+        new EntityTag(Integer.toString(Joiner.on('-').join("sent", queryId, subqueryId, fragmentId).hashCode()));
     Object obj = checkAndAddCache(request, eTag);
     if (obj instanceof Response) {
       return (Response) obj;
@@ -184,7 +186,7 @@ public final class LogResource {
     PipedStreamingOutput entity = new PipedStreamingOutput(input);
     response.entity(entity);
 
-    server.startSentLogDataStream(queryId, subQueryId, fragmentId, writer);
+    server.startSentLogDataStream(new SubQueryId(queryId, subqueryId), fragmentId, writer);
 
     return response.build();
   }
@@ -193,7 +195,7 @@ public final class LogResource {
    * Get aggregated summary of all data sent.
    * 
    * @param queryId query id.
-   * @param subQueryId subquery id.
+   * @param subqueryId subquery id.
    * @param request the current request.
    * @return the profiling logs of the query across all workers
    * @throws DbException if there is an error in the database.
@@ -201,13 +203,13 @@ public final class LogResource {
   @GET
   @Path("aggregated_sent")
   public Response getAggregatedSentLogs(@QueryParam("queryId") final Long queryId,
-      @DefaultValue("0") @QueryParam("subQueryId") final long subQueryId, @Context final Request request)
+      @DefaultValue("0") @QueryParam("subqueryId") final long subqueryId, @Context final Request request)
       throws DbException {
 
     Preconditions.checkArgument(queryId != null, "Missing required field queryId.");
 
     EntityTag eTag =
-        new EntityTag(Integer.toString(Joiner.on('-').join("aggregated-sent", queryId, subQueryId).hashCode()));
+        new EntityTag(Integer.toString(Joiner.on('-').join("aggregated-sent", queryId, subqueryId).hashCode()));
     Object obj = checkAndAddCache(request, eTag);
     if (obj instanceof Response) {
       return (Response) obj;
@@ -229,14 +231,14 @@ public final class LogResource {
     PipedStreamingOutput entity = new PipedStreamingOutput(input);
     response.entity(entity);
 
-    server.startAggregatedSentLogDataStream(queryId, subQueryId, writer);
+    server.startAggregatedSentLogDataStream(new SubQueryId(queryId, subqueryId), writer);
 
     return response.build();
   }
 
   /**
    * @param queryId query id.
-   * @param subQueryId subquery id.
+   * @param subqueryId subquery id.
    * @param fragmentId the fragment id.
    * @param request the current request.
    * @return the range for which we have profiling info
@@ -245,14 +247,14 @@ public final class LogResource {
   @GET
   @Path("range")
   public Response getRange(@QueryParam("queryId") final Long queryId,
-      @DefaultValue("0") @QueryParam("subQueryId") final long subQueryId,
+      @DefaultValue("0") @QueryParam("subqueryId") final long subqueryId,
       @QueryParam("fragmentId") final Long fragmentId, @Context final Request request) throws DbException {
 
     Preconditions.checkArgument(queryId != null, "Missing required field queryId.");
     Preconditions.checkArgument(fragmentId != null, "Missing required field fragmentId.");
 
     EntityTag eTag =
-        new EntityTag(Integer.toString(Joiner.on('-').join("range", subQueryId, queryId, fragmentId).hashCode()));
+        new EntityTag(Integer.toString(Joiner.on('-').join("range", subqueryId, queryId, fragmentId).hashCode()));
     Object obj = checkAndAddCache(request, eTag);
     if (obj instanceof Response) {
       return (Response) obj;
@@ -274,7 +276,7 @@ public final class LogResource {
     PipedStreamingOutput entity = new PipedStreamingOutput(input);
     response.entity(entity);
 
-    server.startRangeDataStream(queryId, subQueryId, fragmentId, writer);
+    server.startRangeDataStream(new SubQueryId(queryId, subqueryId), fragmentId, writer);
 
     return response.build();
   }
@@ -283,7 +285,7 @@ public final class LogResource {
    * Get the number of workers working on a fragment based on profiling logs of a query for the root operators.
    * 
    * @param queryId query id.
-   * @param subQueryId subquery id.
+   * @param subqueryId subquery id.
    * @param fragmentId the fragment id.
    * @param start the start of the range
    * @param end the end of the range
@@ -296,7 +298,7 @@ public final class LogResource {
   @GET
   @Path("histogram")
   public Response getHistogram(@QueryParam("queryId") final Long queryId,
-      @DefaultValue("0") @QueryParam("subQueryId") final long subQueryId,
+      @DefaultValue("0") @QueryParam("subqueryId") final long subqueryId,
       @QueryParam("fragmentId") final Long fragmentId, @QueryParam("start") final Long start,
       @QueryParam("end") final Long end, @QueryParam("step") final Long step,
       @DefaultValue("true") @QueryParam("onlyRootOp") final boolean onlyRootOp, @Context final Request request)
@@ -309,7 +311,7 @@ public final class LogResource {
     Preconditions.checkArgument(step != null, "Missing required field step.");
 
     EntityTag eTag =
-        new EntityTag(Integer.toString(Joiner.on('-').join("histogram", queryId, subQueryId, fragmentId, start, end,
+        new EntityTag(Integer.toString(Joiner.on('-').join("histogram", queryId, subqueryId, fragmentId, start, end,
             step, onlyRootOp).hashCode()));
 
     Object obj = checkAndAddCache(request, eTag);
@@ -333,7 +335,8 @@ public final class LogResource {
     PipedStreamingOutput entity = new PipedStreamingOutput(input);
     response.entity(entity);
 
-    server.startHistogramDataStream(queryId, subQueryId, fragmentId, start, end, step, onlyRootOp, writer);
+    server.startHistogramDataStream(new SubQueryId(queryId, subqueryId), fragmentId, start, end, step, onlyRootOp,
+        writer);
 
     return response.build();
   }

--- a/src/edu/washington/escience/myria/coordinator/catalog/MasterCatalog.java
+++ b/src/edu/washington/escience/myria/coordinator/catalog/MasterCatalog.java
@@ -92,7 +92,7 @@ public final class MasterCatalog {
     + "    profiling_mode TEXT,\n" 
     + "    ft_mode TEXT,\n"
     + "    language TEXT);";
-  /** Create the queries table. */
+  /** Create the query full-text search table. */
   private static final String CREATE_QUERIES_FTS =
       "CREATE VIRTUAL TABLE queries_fts USING FTS4(\n"
     + "    query_id INTEGER NOT NULL PRIMARY KEY ASC REFERENCES queries (query_id),\n"

--- a/src/edu/washington/escience/myria/coordinator/catalog/MasterCatalog.java
+++ b/src/edu/washington/escience/myria/coordinator/catalog/MasterCatalog.java
@@ -46,6 +46,7 @@ import edu.washington.escience.myria.api.encoding.QueryStatusEncoding;
 import edu.washington.escience.myria.api.encoding.plan.SubPlanEncoding;
 import edu.washington.escience.myria.parallel.Query;
 import edu.washington.escience.myria.parallel.SocketInfo;
+import edu.washington.escience.myria.parallel.SubQueryId;
 
 /**
  * This class is intended to store the configuration information for a Myria installation.
@@ -97,6 +98,14 @@ public final class MasterCatalog {
       "CREATE VIRTUAL TABLE queries_fts USING FTS4(\n"
     + "    query_id INTEGER NOT NULL PRIMARY KEY ASC REFERENCES queries (query_id),\n"
     + "    raw_query_fts TEXT NOT NULL);";
+  /** Create the query plans table. */
+  private static final String CREATE_QUERY_PLANS =
+      "CREATE TABLE query_plans (\n"
+    + "    query_id INTEGER NOT NULL,\n"
+    + "    subquery_id INTEGER NOT NULL,\n"
+    + "    plan TEXT NOT NULL,\n"
+    + "    PRIMARY KEY (query_id, subquery_id)\n"
+    + ");";
   /** Create the relations table. */
   private static final String CREATE_RELATIONS =
       "CREATE TABLE relations (\n"
@@ -204,6 +213,7 @@ public final class MasterCatalog {
             sqliteConnection.exec(CREATE_ALIVE_WORKERS);
             sqliteConnection.exec(CREATE_QUERIES);
             sqliteConnection.exec(CREATE_QUERIES_FTS);
+            sqliteConnection.exec(CREATE_QUERY_PLANS);
             sqliteConnection.exec(CREATE_RELATIONS);
             sqliteConnection.exec(CREATE_RELATION_SCHEMA);
             sqliteConnection.exec(CREATE_RELATION_SCHEMA_INDEX);
@@ -1816,6 +1826,80 @@ public final class MasterCatalog {
             throw new CatalogException(e);
           }
           return null;
+        }
+      }).get();
+    } catch (InterruptedException | ExecutionException e) {
+      throw new CatalogException(e);
+    }
+  }
+
+  /**
+   * Record the fact that this subquery executed this in the catalog.
+   * 
+   * @param subQueryId the id of the subquery.
+   * @param encodedPlan the plan.
+   * @throws CatalogException if there is an error.
+   */
+  public void setQueryPlan(@Nonnull final SubQueryId subQueryId, @Nonnull final String encodedPlan)
+      throws CatalogException {
+    Preconditions.checkNotNull(subQueryId, "subQueryId");
+    Preconditions.checkNotNull(encodedPlan, "encodedPlan");
+    /* Do the work */
+    try {
+      queue.execute(new SQLiteJob<Void>() {
+        @Override
+        protected Void job(final SQLiteConnection sqliteConnection) throws CatalogException, SQLiteException {
+          try {
+            SQLiteStatement statement =
+                sqliteConnection.prepare("INSERT INTO query_plans (query_id, subquery_id, plan) VALUES (?,?,?);");
+            statement.bind(1, subQueryId.getQueryId());
+            statement.bind(2, subQueryId.getSubqueryId());
+            statement.bind(3, encodedPlan);
+            statement.stepThrough();
+            statement.dispose();
+            statement = null;
+          } catch (final SQLiteException e) {
+            throw new CatalogException(e);
+          }
+          return null;
+        }
+      }).get();
+    } catch (InterruptedException | ExecutionException e) {
+      throw new CatalogException(e);
+    }
+  }
+
+  /**
+   * Get the saved query plan for the target subquery.
+   * 
+   * @param subQueryId the id of the subquery.
+   * @return the saved query plan for the target subquery.
+   * @throws CatalogException if there is an error.
+   */
+  @Nullable
+  public String getQueryPlan(final SubQueryId subQueryId) throws CatalogException {
+    Preconditions.checkNotNull(subQueryId, "subQueryId");
+    /* Do the work */
+    try {
+      return queue.execute(new SQLiteJob<String>() {
+        @Override
+        protected String job(final SQLiteConnection sqliteConnection) throws CatalogException, SQLiteException {
+          String ret = null;
+          try {
+            SQLiteStatement statement =
+                sqliteConnection.prepare("SELECT plan FROM query_plans WHERE query_id=? AND subquery_id=?;");
+            statement.bind(1, subQueryId.getQueryId());
+            statement.bind(2, subQueryId.getSubqueryId());
+
+            if (statement.step()) {
+              ret = statement.columnString(0);
+            }
+            statement.dispose();
+            statement = null;
+          } catch (final SQLiteException e) {
+            throw new CatalogException(e);
+          }
+          return ret;
         }
       }).get();
     } catch (InterruptedException | ExecutionException e) {

--- a/src/edu/washington/escience/myria/operator/Operator.java
+++ b/src/edu/washington/escience/myria/operator/Operator.java
@@ -19,6 +19,7 @@ import edu.washington.escience.myria.Schema;
 import edu.washington.escience.myria.parallel.LocalFragment;
 import edu.washington.escience.myria.parallel.LocalFragmentResourceManager;
 import edu.washington.escience.myria.parallel.LocalSubQuery;
+import edu.washington.escience.myria.parallel.SubQueryId;
 import edu.washington.escience.myria.parallel.WorkerSubQuery;
 import edu.washington.escience.myria.profiling.ProfilingLogger;
 import edu.washington.escience.myria.storage.TupleBatch;
@@ -105,11 +106,11 @@ public abstract class Operator implements Serializable {
   }
 
   /**
-   * @return return query id.
+   * @return return subquery id.
    */
-  public long getQueryId() {
+  public SubQueryId getSubQueryId() {
     return ((LocalFragmentResourceManager) execEnvVars.get(MyriaConstants.EXEC_ENV_VAR_FRAGMENT_RESOURCE_MANAGER))
-        .getFragment().getLocalSubQuery().getSubQueryId().getQueryId();
+        .getFragment().getLocalSubQuery().getSubQueryId();
   }
 
   /**

--- a/src/edu/washington/escience/myria/parallel/JsonSubQuery.java
+++ b/src/edu/washington/escience/myria/parallel/JsonSubQuery.java
@@ -72,7 +72,7 @@ public final class JsonSubQuery extends QueryPlan {
       serverPlan = new SubQueryPlan(new SinkRoot(new EOSSource()));
     }
 
-    subQueryQ.addFirst(new SubQuery(serverPlan, workerPlans));
+    subQueryQ.addFirst(new SubQuery(null, serverPlan, workerPlans, true));
   }
 
   @Override

--- a/src/edu/washington/escience/myria/parallel/Query.java
+++ b/src/edu/washington/escience/myria/parallel/Query.java
@@ -179,13 +179,8 @@ public final class Query {
       currentSubQuery.setSubQueryId(new SubQueryId(queryId, subqueryId));
       addDerivedSubQueries(currentSubQuery);
 
-      /*
-       * TODO - revisit when we support profiling with sequences.
-       * 
-       * We only support profiling a single subquery, so disable profiling if subqueryId != 0.
-       */
       Set<ProfilingMode> profilingMode = getProfilingMode();
-      if (subqueryId != 0) {
+      if (!currentSubQuery.isProfileable()) {
         profilingMode = ImmutableSet.of();
       }
 

--- a/src/edu/washington/escience/myria/parallel/Query.java
+++ b/src/edu/washington/escience/myria/parallel/Query.java
@@ -176,12 +176,17 @@ public final class Query {
     }
     if (!subQueryQ.isEmpty()) {
       currentSubQuery = subQueryQ.removeFirst();
-      currentSubQuery.setSubQueryId(new SubQueryId(queryId, subqueryId));
+      SubQueryId sqId = new SubQueryId(queryId, subqueryId);
+      currentSubQuery.setSubQueryId(sqId);
       addDerivedSubQueries(currentSubQuery);
 
       Set<ProfilingMode> profilingMode = getProfilingMode();
-      if (!currentSubQuery.isProfileable()) {
-        profilingMode = ImmutableSet.of();
+      if (!profilingMode.isEmpty()) {
+        if (!currentSubQuery.isProfileable()) {
+          profilingMode = ImmutableSet.of();
+        } else {
+          server.setQueryPlan(sqId, currentSubQuery.getEncodedPlan());
+        }
       }
 
       QueryConstruct.setQueryExecutionOptions(currentSubQuery.getWorkerPlans(), ftMode, profilingMode);

--- a/src/edu/washington/escience/myria/parallel/QueryManager.java
+++ b/src/edu/washington/escience/myria/parallel/QueryManager.java
@@ -479,7 +479,7 @@ public class QueryManager {
     if (!canSubmitQuery()) {
       throw new DbException("Cannot submit query");
     }
-    if (query.profilingMode.size() > 0) {
+    if (!query.profilingMode.isEmpty()) {
       if (!server.getDBMS().equals(MyriaConstants.STORAGE_SYSTEM_POSTGRESQL)) {
         throw new DbException("Profiling mode is only supported when using Postgres as the storage system.");
       }

--- a/src/edu/washington/escience/myria/parallel/QueryManager.java
+++ b/src/edu/washington/escience/myria/parallel/QueryManager.java
@@ -480,10 +480,6 @@ public class QueryManager {
       throw new DbException("Cannot submit query");
     }
     if (query.profilingMode.size() > 0) {
-      if (!(plan instanceof SubQuery || plan instanceof JsonSubQuery)) {
-        throw new DbException("Profiling mode is not supported for plans (" + plan.getClass().getSimpleName()
-            + ") that may contain multiple subqueries.");
-      }
       if (!server.getDBMS().equals(MyriaConstants.STORAGE_SYSTEM_POSTGRESQL)) {
         throw new DbException("Profiling mode is only supported when using Postgres as the storage system.");
       }

--- a/src/edu/washington/escience/myria/parallel/Server.java
+++ b/src/edu/washington/escience/myria/parallel/Server.java
@@ -43,6 +43,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.ListenableFuture;
 
 import edu.washington.escience.myria.CsvTupleWriter;
@@ -1372,7 +1373,7 @@ public final class Server {
      */
     ObjectMapper mapper = MyriaJsonMapperProvider.getMapper();
     List<Map<String, Object>> fragments;
-    ImmutableSet.Builder<Integer> actualWorkersB = ImmutableSet.builder();
+    Set<Integer> actualWorkers = Sets.newHashSet();
     try {
       fragments = mapper.readValue(plan, new TypeReference<List<Map<String, Object>>>() {
       });
@@ -1385,7 +1386,7 @@ public final class Server {
         try {
           @SuppressWarnings("unchecked")
           Collection<Integer> curWorkers = (Collection<Integer>) fragWorkers;
-          actualWorkersB.addAll(curWorkers);
+          actualWorkers.addAll(curWorkers);
         } catch (ClassCastException e) {
           throw new IllegalStateException("Expected fragWorkers to be a collection of ints, instead found "
               + fragWorkers);
@@ -1394,7 +1395,9 @@ public final class Server {
     } catch (IOException e) {
       throw new IllegalArgumentException("Error deserializing workers from encoded plan " + plan, e);
     }
-    return actualWorkersB.build();
+    /* Remove the MASTER from the set. */
+    actualWorkers.remove(MyriaConstants.MASTER_ID);
+    return actualWorkers;
   }
 
   /**

--- a/src/edu/washington/escience/myria/parallel/Server.java
+++ b/src/edu/washington/escience/myria/parallel/Server.java
@@ -1901,4 +1901,18 @@ public final class Server {
       throw new DbException(e);
     }
   }
+
+  /**
+   * @param subQueryId the query whose plan to look up.
+   * @return the execution plan for this query.
+   * @throws DbException if there is an error getting the query status.
+   */
+  @Nullable
+  public String getQueryPlan(@Nonnull final SubQueryId subQueryId) throws DbException {
+    try {
+      return catalog.getQueryPlan(subQueryId);
+    } catch (CatalogException e) {
+      throw new DbException(e);
+    }
+  }
 }

--- a/src/edu/washington/escience/myria/parallel/Server.java
+++ b/src/edu/washington/escience/myria/parallel/Server.java
@@ -1886,4 +1886,19 @@ public final class Server {
       throw new DbException(e);
     }
   }
+
+  /**
+   * Record the fact that this subquery executed this in the catalog.
+   * 
+   * @param subQueryId the id of the subquery.
+   * @param encodedPlan the plan.
+   * @throws DbException if there is an error in the catalog.
+   */
+  public void setQueryPlan(final SubQueryId subQueryId, @Nonnull final String encodedPlan) throws DbException {
+    try {
+      catalog.setQueryPlan(subQueryId, encodedPlan);
+    } catch (CatalogException e) {
+      throw new DbException(e);
+    }
+  }
 }

--- a/src/edu/washington/escience/myria/parallel/SubQuery.java
+++ b/src/edu/washington/escience/myria/parallel/SubQuery.java
@@ -10,7 +10,6 @@ import javax.annotation.Nullable;
 
 import org.joda.time.DateTime;
 
-import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Verify;
 import com.google.common.collect.ImmutableMap;
@@ -41,7 +40,7 @@ public final class SubQuery extends QueryPlan {
   /** The execution statistics about this {@link SubQuery}. */
   private final ExecutionStatistics executionStats;
   /** Whether this subquery can be profiled. */
-  private final boolean profileable;
+  private final String planEncoding;
 
   /**
    * Construct a new {@link SubQuery} object for this {@link SubQuery}, with pending {@link SubQueryId}.
@@ -71,14 +70,14 @@ public final class SubQuery extends QueryPlan {
    * @param subQueryId the id of this {@link SubQuery}
    * @param masterPlan the master's {@link SubQueryPlan}
    * @param workerPlans the {@link SubQueryPlan} for each worker
-   * @param profileable whether this subquery can be profiled
+   * @param planEncoding the encoding of the query plan, for subsequent recording.
    */
   public SubQuery(@Nullable final SubQueryId subQueryId, final SubQueryPlan masterPlan,
-      final Map<Integer, SubQueryPlan> workerPlans, @Nullable final Boolean profileable) {
+      final Map<Integer, SubQueryPlan> workerPlans, @Nullable final String planEncoding) {
     this.subQueryId = subQueryId;
     this.masterPlan = Objects.requireNonNull(masterPlan, "masterPlan");
     this.workerPlans = Objects.requireNonNull(workerPlans, "workerPlans");
-    this.profileable = MoreObjects.firstNonNull(profileable, Boolean.FALSE);
+    this.planEncoding = planEncoding;
     executionStats = new ExecutionStatistics();
 
     ImmutableSet.Builder<RelationKey> read = ImmutableSet.<RelationKey> builder().addAll(masterPlan.readSet());
@@ -203,7 +202,16 @@ public final class SubQuery extends QueryPlan {
    * @return true if this subquery can be profiled.
    */
   public boolean isProfileable() {
-    return profileable;
+    return planEncoding != null;
+  }
+
+  /**
+   * Returns the encoded JSON query plan.
+   * 
+   * @return the encoded JSON query plan.
+   */
+  public String getEncodedPlan() {
+    return planEncoding;
   }
 
   @Override

--- a/src/edu/washington/escience/myria/profiling/ProfilingLogger.java
+++ b/src/edu/washington/escience/myria/profiling/ProfilingLogger.java
@@ -17,6 +17,7 @@ import edu.washington.escience.myria.accessmethod.ConnectionInfo;
 import edu.washington.escience.myria.accessmethod.JdbcAccessMethod;
 import edu.washington.escience.myria.operator.Operator;
 import edu.washington.escience.myria.parallel.ResourceStats;
+import edu.washington.escience.myria.parallel.SubQueryId;
 import edu.washington.escience.myria.parallel.WorkerSubQuery;
 import edu.washington.escience.myria.storage.TupleBatch;
 import edu.washington.escience.myria.storage.TupleBatchBuffer;
@@ -75,7 +76,9 @@ public class ProfilingLogger {
   protected void createSentIndex() throws DbException {
     final Schema schema = MyriaConstants.SENT_PROFILING_SCHEMA;
 
-    List<IndexRef> index = ImmutableList.of(IndexRef.of(schema, "queryId"), IndexRef.of(schema, "fragmentId"));
+    List<IndexRef> index =
+        ImmutableList.of(IndexRef.of(schema, "queryId"), IndexRef.of(schema, "subQueryId"), IndexRef.of(schema,
+            "fragmentId"));
     try {
       accessMethod.createIndexIfNotExists(MyriaConstants.SENT_PROFILING_RELATION, schema, index);
     } catch (DbException e) {
@@ -105,11 +108,12 @@ public class ProfilingLogger {
     final Schema schema = MyriaConstants.EVENT_PROFILING_SCHEMA;
 
     List<IndexRef> rootOpsIndex =
-        ImmutableList.of(IndexRef.of(schema, "queryId"), IndexRef.of(schema, "fragmentId"), IndexRef.of(schema,
-            "startTime"), IndexRef.of(schema, "endTime"));
+        ImmutableList.of(IndexRef.of(schema, "queryId"), IndexRef.of(schema, "subQueryId"), IndexRef.of(schema,
+            "fragmentId"), IndexRef.of(schema, "startTime"), IndexRef.of(schema, "endTime"));
     List<IndexRef> filterIndex =
-        ImmutableList.of(IndexRef.of(schema, "queryId"), IndexRef.of(schema, "fragmentId"),
-            IndexRef.of(schema, "opId"), IndexRef.of(schema, "startTime"), IndexRef.of(schema, "endTime"));
+        ImmutableList.of(IndexRef.of(schema, "queryId"), IndexRef.of(schema, "subQueryId"), IndexRef.of(schema,
+            "fragmentId"), IndexRef.of(schema, "opId"), IndexRef.of(schema, "startTime"), IndexRef
+            .of(schema, "endTime"));
 
     try {
       accessMethod.createIndexIfNotExists(MyriaConstants.EVENT_PROFILING_RELATION, schema, rootOpsIndex);
@@ -159,13 +163,14 @@ public class ProfilingLogger {
    */
   public synchronized void recordEvent(final Operator operator, final long numTuples, final long startTime)
       throws DbException {
-
-    events.putLong(0, operator.getQueryId());
-    events.putInt(1, operator.getFragmentId());
-    events.putInt(2, operator.getOpId());
-    events.putLong(3, startTime);
-    events.putLong(4, getTime(operator));
-    events.putLong(5, numTuples);
+    SubQueryId sq = operator.getSubQueryId();
+    events.putLong(0, sq.getQueryId());
+    events.putInt(1, (int) sq.getSubqueryId());
+    events.putInt(2, operator.getFragmentId());
+    events.putInt(3, operator.getOpId());
+    events.putLong(4, startTime);
+    events.putLong(5, getTime(operator));
+    events.putLong(6, numTuples);
 
     flush(MyriaConstants.EVENT_PROFILING_RELATION, events.popFilled());
   }
@@ -181,11 +186,13 @@ public class ProfilingLogger {
    */
   public synchronized void recordSent(final Operator operator, final int numTuples, final int destWorkerId)
       throws DbException {
-    sent.putLong(0, operator.getQueryId());
-    sent.putInt(1, operator.getFragmentId());
-    sent.putLong(2, getTime(operator));
-    sent.putLong(3, numTuples);
-    sent.putInt(4, destWorkerId);
+    SubQueryId sq = operator.getSubQueryId();
+    events.putLong(0, sq.getQueryId());
+    events.putInt(1, (int) sq.getSubqueryId());
+    sent.putInt(2, operator.getFragmentId());
+    sent.putLong(3, getTime(operator));
+    sent.putLong(4, numTuples);
+    sent.putInt(5, destWorkerId);
 
     flush(MyriaConstants.SENT_PROFILING_RELATION, sent.popFilled());
   }

--- a/src/edu/washington/escience/myria/profiling/ProfilingLogger.java
+++ b/src/edu/washington/escience/myria/profiling/ProfilingLogger.java
@@ -187,8 +187,8 @@ public class ProfilingLogger {
   public synchronized void recordSent(final Operator operator, final int numTuples, final int destWorkerId)
       throws DbException {
     SubQueryId sq = operator.getSubQueryId();
-    events.putLong(0, sq.getQueryId());
-    events.putInt(1, (int) sq.getSubqueryId());
+    sent.putLong(0, sq.getQueryId());
+    sent.putInt(1, (int) sq.getSubqueryId());
     sent.putInt(2, operator.getFragmentId());
     sent.putLong(3, getTime(operator));
     sent.putLong(4, numTuples);

--- a/systemtest/edu/washington/escience/myria/systemtest/ServerTest.java
+++ b/systemtest/edu/washington/escience/myria/systemtest/ServerTest.java
@@ -14,7 +14,6 @@ import edu.washington.escience.myria.api.encoding.QueryEncoding;
 import edu.washington.escience.myria.operator.EOSSource;
 import edu.washington.escience.myria.operator.SinkRoot;
 import edu.washington.escience.myria.parallel.QueryPlan;
-import edu.washington.escience.myria.parallel.Sequence;
 import edu.washington.escience.myria.parallel.SubQuery;
 import edu.washington.escience.myria.parallel.SubQueryPlan;
 
@@ -34,26 +33,6 @@ public class ServerTest extends SystemTestBase {
       server.getQueryManager().submitQuery(query, plan);
     } catch (DbException e) {
       assertTrue(e.getMessage().contains("Profiling mode is only supported when using Postgres as the storage system."));
-      throw e;
-    }
-  }
-
-  /**
-   * Test that profiling mode fails when we use multiple queries.
-   */
-  @Test(expected = DbException.class)
-  public void testProfilingWithMultipleQueries() throws Exception {
-    SubQueryPlan serverPlan = new SubQueryPlan(new SinkRoot(new EOSSource()));
-    QueryPlan frag = new SubQuery(serverPlan, new HashMap<Integer, SubQueryPlan>());
-    QueryPlan plan = new Sequence(ImmutableList.of(frag, frag));
-    QueryEncoding query = new QueryEncoding();
-    query.rawQuery = "testDatalog";
-    query.logicalRa = "testRa";
-    query.profilingMode = ImmutableList.of(ProfilingMode.QUERY);
-    try {
-      server.getQueryManager().submitQuery(query, plan);
-    } catch (DbException e) {
-      assertTrue(e.getMessage().contains("Profiling mode is not supported for plans"));
       throw e;
     }
   }


### PR DESCRIPTION
FYI @domoritz , I need this pretty bad for some of the work I'm doing and I'm thinking about how to get there.

A straw proposal that involves no frontend work is to simply add logging of events and physical plans for all subqueries and then add a subquery parameter to the frontend. I'm going to start there.

- [x] update the profiling and sent log tables

- [x] update the profiling queries and API calls

- [x] let the backend profile individual subqueries. (Rather than the workaround here: https://github.com/uwescience/myria/blob/b95cfcc05ff180bf133dea1c4b1113af6cdc3a54/src/edu/washington/escience/myria/parallel/Query.java#L182)

- [x] log the physical plans for every subquery. (Rather than the workaround here: https://github.com/uwescience/myria/blob/b95cfcc05ff180bf133dea1c4b1113af6cdc3a54/src/edu/washington/escience/myria/parallel/QueryManager.java#L491)

- [x] modify myria-web; create an issue there and link it here. See uwescience/myria-web#246