### PR TITLE
LeapFrogJoin: gracefully handle case when tables==null

### DIFF
--- a/src/edu/washington/escience/myria/operator/LeapFrogJoin.java
+++ b/src/edu/washington/escience/myria/operator/LeapFrogJoin.java
@@ -1160,7 +1160,10 @@ public class LeapFrogJoin extends NAryOperator {
    * @return number of tuples in all the hash tables.
    */
   public long getNumTuplesInHashTables() {
-    long sum = 0;
+    if (tables == null) {
+      return 0L;
+    }
+    long sum = 0L;
     for (MutableTupleBuffer table : tables) {
       if (table != null) {
         sum += table.numTuples();


### PR DESCRIPTION
Fix #689.

My belief is that the following happens: a fragment reaches EOS before
the entire query does. In this case, the root operator calls `cleanup()`
on its children, which leads to LFJ nulling out the `.tables` field.
However, the resource profiling code still measures the hash table
size, and thus was triggering an NPE.

@jingjingwang would appreciate your thoughts to see if this explanation makes any sense to you.