### PR TITLE
TupleBatch: remove expensive check

### DIFF
--- a/src/edu/washington/escience/myria/storage/TupleBatch.java
+++ b/src/edu/washington/escience/myria/storage/TupleBatch.java
@@ -191,8 +191,6 @@ public class TupleBatch implements ReadableTable, Serializable {
 
   @Override
   public final long getLong(final int column, final int row) {
-    Preconditions.checkArgument(columns.get(column).size() >= numTuples, "numTuples %s columnsize %s", numTuples,
-        columns.get(column).size());
     return columns.get(column).getLong(row);
   }
 


### PR DESCRIPTION
Not sure if this was real or lurking from a debug scenario, but it's
expensive and redundant -- the storage engines down the line will do the
check.