### PR TITLE
Added configuration option to specify a database port

### DIFF
--- a/myriadeploy/deployment.cfg.postgres
+++ b/myriadeploy/deployment.cfg.postgres
@@ -5,6 +5,9 @@ name = testMyriadeploy
 dbms = postgresql
 database_name = myria1
 database_password = <password>
+
+# Uncomment if need to set a custom db port, otherwise default will be used
+#database_port = 5401
 # Uncomment if need to set a specific username; does not work for localhost
 #username = dhalperi
 # Uncomment to set the maximum heap size of the Java processes

--- a/myriadeploy/myriadeploy.py
+++ b/myriadeploy/myriadeploy.py
@@ -35,6 +35,13 @@ def read_config_file(filename='deployment.cfg'):
     except ConfigParser.NoOptionError:
         ret['ssl'] = False
 
+    # Check for custom postgres port
+    try:
+        ret['database_port'] = config.get('deployment', 'database_port')
+        ret['custom_port'] = True
+    except ConfigParser.NoOptionError:
+        ret['custom_port'] = False
+
     # Helper function
     def split_hostportpathdbname_key_append_id(hostport):
         "Splits id = host,port,path,db_name into a tuple (host, port, path, db_name, id)."

--- a/src/edu/washington/escience/myria/MyriaConstants.java
+++ b/src/edu/washington/escience/myria/MyriaConstants.java
@@ -185,7 +185,7 @@ public final class MyriaConstants {
   /**
    * PostgreSQL port.
    */
-  public static final int STORAGE_POSTGRESQL_PORT = 5401;
+  public static final int STORAGE_POSTGRESQL_PORT = 5432;
 
   /**
    * Default value for {@link MyriaSystemConfigKeys#TCP_CONNECTION_TIMEOUT_MILLIS}.

--- a/src/edu/washington/escience/myria/accessmethod/ConnectionInfo.java
+++ b/src/edu/washington/escience/myria/accessmethod/ConnectionInfo.java
@@ -69,10 +69,11 @@ public abstract class ConnectionInfo {
    * @param workerId the worker identification.
    * @param databaseName the database name for JDBC databases; ignored for non-JDBC
    * @param databasePassword the database password for JDBC databases; ignored for non-JDBC
+   * @param databasePort the port the database is using; pass null to use default port
    * @return the JSON string representation of the connection information.
    */
   public static String toJson(final String dbms, final String hostName, final String description, final String dirName,
-      final String workerId, final String databaseName, final String databasePassword) {
+      final String workerId, final String databaseName, final String databasePassword, final Integer databasePort) {
     Objects.requireNonNull(dbms);
     String result = "";
     String host;
@@ -102,7 +103,13 @@ public abstract class ConnectionInfo {
         // Now it is hardcoded to use a specific connection info, which allows only one
         // myria instance per machine in the cluster
         host = hostName;
-        port = MyriaConstants.STORAGE_MONETDB_PORT;
+            
+        if (databasePort == null) {
+            port = MyriaConstants.STORAGE_MONETDB_PORT;
+        } else {
+            port = databasePort;
+        }
+            
         user = MyriaConstants.STORAGE_JDBC_USERNAME;
         jdbcDriverName = "nl.cwi.monetdb.jdbc.MonetDriver";
         jdbcInfo = JdbcInfo.of(jdbcDriverName, dbms, host, port, databaseName, user, databasePassword);
@@ -114,7 +121,13 @@ public abstract class ConnectionInfo {
         // Now it is hardcoded to use a specific connection info, which allows only one
         // myria instance per machine in the cluster
         host = hostName;
-        port = MyriaConstants.STORAGE_POSTGRESQL_PORT;
+            
+        if (databasePort == null) {
+            port = MyriaConstants.STORAGE_POSTGRESQL_PORT;
+        } else {
+            port = databasePort;
+        }
+            
         user = MyriaConstants.STORAGE_JDBC_USERNAME;
         jdbcDriverName = "org.postgresql.Driver";
         jdbcInfo = JdbcInfo.of(jdbcDriverName, dbms, host, port, databaseName, user, databasePassword);
@@ -126,7 +139,13 @@ public abstract class ConnectionInfo {
         // Now it is hardcoded to use a specific connection info, which allows only one
         // myria instance per machine in the cluster
         host = hostName;
-        port = MyriaConstants.STORAGE_MYSQL_PORT;
+
+        if (databasePort == null) {
+            port = MyriaConstants.STORAGE_MYSQL_PORT;
+        } else {
+            port = databasePort;
+        }
+            
         user = MyriaConstants.STORAGE_JDBC_USERNAME;
         jdbcDriverName = "com.mysql.jdbc.Driver";
         jdbcInfo = JdbcInfo.of(jdbcDriverName, dbms, host, port, databaseName, user, databasePassword);

--- a/src/edu/washington/escience/myria/coordinator/catalog/CatalogMaker.java
+++ b/src/edu/washington/escience/myria/coordinator/catalog/CatalogMaker.java
@@ -220,8 +220,16 @@ public final class CatalogMaker {
       final String host = wc.getWorkers().get(Integer.parseInt(workerId)).getHost();
       final String databaseName = config.get("databaseNames").get(workerId);
       final String databasePassword = config.get("deployment").get("database_password");
+      Integer databasePort;
+      try {
+          databasePort = Integer.parseInt(config.get("deployment").get("database_port"));
+      } catch (NumberFormatException e) {
+          // No custom database port set, ConnectionInfo.toJson will use default
+          databasePort = null;
+      }
+        
       final String jsonConnInfo =
-          ConnectionInfo.toJson(dbms, host, description, workerWorkingDir, workerId, databaseName, databasePassword);
+          ConnectionInfo.toJson(dbms, host, description, workerWorkingDir, workerId, databaseName, databasePassword, databasePort);
       configurationValues.put(MyriaSystemConfigKeys.WORKER_STORAGE_DATABASE_CONN_INFO, jsonConnInfo);
 
       /* Set them all in the worker catalog. */


### PR DESCRIPTION
With this commit, myria will no longer have its postgres port hardcoded
to 5401.  Rather, it will use the default port of each database,
unless otherwise specified by the user in the configuration file.

The production cluster config file will need to add a database port setting set to 5401, since our postgres instance listens on this port, and not the default.