### PR TITLE
travis-refine-cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,4 @@ sudo: false
 
 cache:
   directories:
-  - $HOME/.gradle
+  - $HOME/.gradle/caches


### PR DESCRIPTION
Don't cache the entire `$HOME/.gradle` directory, because it may
take time. Instead, follow this advice
http://forums.gradle.org/gradle/topics/travis-ci-caching-dependencies
and only cache the `.gradle/caches` directory.