### PR TITLE
do not call getSchema() in setChildren()

### DIFF
--- a/jsonQueries/nullChild_jortiz/ThreeWayLocalJoin.json
+++ b/jsonQueries/nullChild_jortiz/ThreeWayLocalJoin.json
@@ -1,0 +1,85 @@
+{
+    "profilingMode": [], 
+    "logicalRa": "query", 
+    "language": "MyriaL", 
+    "rawQuery": "query", 
+    "plan": {
+        "fragments": [
+            {
+                "operators": [
+                    {
+                        "opName": "V0", 
+                        "opType": "SinkRoot", 
+                        "opId": 0, 
+                        "argChild": 200
+                    },
+                    {
+                        "opType": "SymmetricHashJoin", 
+                        "argColumns1": [0], 
+                        "argColumns2": [0], 
+                        "argColumnNames": [
+                            "col1"
+                        ], 
+                        "argChild2": 18, 
+                        "argChild1": 17, 
+                        "opId": 200, 
+                        "argSelect2": [
+                        ], 
+                        "opName": "MyriaSymmetricHashJoin", 
+                        "argSelect1": [
+                            0
+                        ]
+                    }, 
+                    {
+                        "relationKey": {
+                            "userName": "jwang", 
+                            "relationName": "smallTable", 
+                            "programName": "global_join"
+                        }, 
+                        "opType": "TableScan", 
+                        "opName": "MyriaScan", 
+                        "opId": 17
+                    },
+                    {
+                        "opType": "SymmetricHashJoin", 
+                        "argColumns1": [0], 
+                        "argColumns2": [0], 
+                        "argColumnNames": [
+                            "col1"
+                        ], 
+                        "argChild2": 20, 
+                        "argChild1": 19, 
+                        "opId": 18, 
+                        "argSelect2": [
+                        ], 
+                        "opName": "MyriaSymmetricHashJoin", 
+                        "argSelect1": [
+                            0
+                        ]
+                    }, 
+                    {
+                        "relationKey": {
+                            "userName": "jwang", 
+                            "relationName": "smallTable", 
+                            "programName": "global_join"
+                        }, 
+                        "opType": "TableScan", 
+                        "opName": "MyriaScan", 
+                        "opId": 19
+                    }, 
+                    {
+                        "relationKey": {
+                            "userName": "jwang", 
+                            "relationName": "smallTable", 
+                            "programName": "global_join"
+                        }, 
+                        "opType": "TableScan", 
+                        "opName": "MyriaScan", 
+                        "opId": 20
+                    }
+                ]
+            }
+        ], 
+        "type": "SubQuery"
+    }
+}

--- a/src/edu/washington/escience/myria/operator/BinaryOperator.java
+++ b/src/edu/washington/escience/myria/operator/BinaryOperator.java
@@ -58,8 +58,6 @@ public abstract class BinaryOperator extends Operator {
     Preconditions.checkNotNull(children[1], "Operator opId=%s has its second child to be null", opId);
     left = children[0];
     right = children[1];
-    /* Generate the Schema now as a way of sanity-checking the constructor arguments. */
-    getSchema();
   }
 
 }

--- a/src/edu/washington/escience/myria/operator/UnaryOperator.java
+++ b/src/edu/washington/escience/myria/operator/UnaryOperator.java
@@ -55,8 +55,6 @@ public abstract class UnaryOperator extends Operator {
         "Operator opId=%s setChildren() must be called with an array of length 1", opId);
     Preconditions.checkNotNull(children[0], "Unary operator opId=%s has its child to be null", opId);
     child = children[0];
-    /* Trigger Schema updating. */
-    getSchema();
   }
 
 }


### PR DESCRIPTION
During a fragment instantiation, the order of calls to operators' connect() can be arbitrary. getSchema() goes to generateSchema() which may need to know the children of an operator that may not have been set by connect(). On the other hand, I think it is unnecessary to call getSchema() in setChildren() since we can always generate schema after childrens are being set.