### PR TITLE
Adding all *FileScan operators to list of singleton operators.

### DIFF
--- a/src/edu/washington/escience/myria/api/encoding/QueryConstruct.java
+++ b/src/edu/washington/escience/myria/api/encoding/QueryConstruct.java
@@ -317,7 +317,9 @@ public class QueryConstruct {
     for (PlanFragmentEncoding fragment : fragments) {
       for (OperatorEncoding<?> operator : fragment.operators) {
         if (operator instanceof CollectConsumerEncoding || operator instanceof SingletonEncoding
-            || operator instanceof EOSControllerEncoding) {
+            || operator instanceof EOSControllerEncoding || operator instanceof BinaryFileScanEncoding
+            || operator instanceof FileScanEncoding || operator instanceof NChiladaFileScanEncoding
+            || operator instanceof SeaFlowFileScanEncoding || operator instanceof TipsyFileScanEncoding) {
           if (fragment.workers == null) {
             fragment.workers = singletonWorkers;
           } else {

--- a/src/edu/washington/escience/myria/api/encoding/QueryConstruct.java
+++ b/src/edu/washington/escience/myria/api/encoding/QueryConstruct.java
@@ -52,6 +52,9 @@ import edu.washington.escience.myria.parallel.SubQuery;
 import edu.washington.escience.myria.parallel.SubQueryPlan;
 
 public class QueryConstruct {
+
+  private static final org.slf4j.Logger LOGGER = org.slf4j.LoggerFactory.getLogger(QueryConstruct.class);
+
   /**
    * Instantiate the server's desired physical plan from a list of JSON encodings of fragments. This list must contain a
    * self-consistent, complete query. All fragments will be executed in parallel.
@@ -321,6 +324,10 @@ public class QueryConstruct {
             || operator instanceof FileScanEncoding || operator instanceof NChiladaFileScanEncoding
             || operator instanceof SeaFlowFileScanEncoding || operator instanceof TipsyFileScanEncoding) {
           if (fragment.workers == null) {
+            String encodingTypeName = operator.getClass().getSimpleName();
+            String operatorTypeName = encodingTypeName.substring(0, encodingTypeName.indexOf("Encoding"));
+            LOGGER.warn("{} operator can only be instantiated on a single worker, assigning to random worker",
+                operatorTypeName);
             fragment.workers = singletonWorkers;
           } else {
             Preconditions.checkArgument(fragment.workers.size() == 1,

--- a/systemtest/edu/washington/escience/myria/systemtest/JsonOperatorTests.java
+++ b/systemtest/edu/washington/escience/myria/systemtest/JsonOperatorTests.java
@@ -123,7 +123,7 @@ public class JsonOperatorTests extends SystemTestBase {
         JsonAPIUtils.download("localhost", masterDaemonPort, outputRelation.getUserName(), outputRelation
             .getProgramName(), outputRelation.getRelationName(), "json");
     String expectedData =
-        "[{\"string_array\":\"a:b:c:d:e:f\",\"string_array_splits\":\"a\"},{\"string_array\":\"a:b:c:d:e:f\",\"string_array_splits\":\"b\"},{\"string_array\":\"a:b:c:d:e:f\",\"string_array_splits\":\"c\"},{\"string_array\":\"a:b:c:d:e:f\",\"string_array_splits\":\"d\"},{\"string_array\":\"a:b:c:d:e:f\",\"string_array_splits\":\"e\"},{\"string_array\":\"a:b:c:d:e:f\",\"string_array_splits\":\"f\"},{\"string_array\":\"a:b:c:d:e:f\",\"string_array_splits\":\"a\"},{\"string_array\":\"a:b:c:d:e:f\",\"string_array_splits\":\"b\"},{\"string_array\":\"a:b:c:d:e:f\",\"string_array_splits\":\"c\"},{\"string_array\":\"a:b:c:d:e:f\",\"string_array_splits\":\"d\"},{\"string_array\":\"a:b:c:d:e:f\",\"string_array_splits\":\"e\"},{\"string_array\":\"a:b:c:d:e:f\",\"string_array_splits\":\"f\"}]";
+        "[{\"string_array\":\"a:b:c:d:e:f\",\"string_array_splits\":\"a\"},{\"string_array\":\"a:b:c:d:e:f\",\"string_array_splits\":\"b\"},{\"string_array\":\"a:b:c:d:e:f\",\"string_array_splits\":\"c\"},{\"string_array\":\"a:b:c:d:e:f\",\"string_array_splits\":\"d\"},{\"string_array\":\"a:b:c:d:e:f\",\"string_array_splits\":\"e\"},{\"string_array\":\"a:b:c:d:e:f\",\"string_array_splits\":\"f\"}]";
     assertEquals(data, expectedData);
   }
 }


### PR DESCRIPTION
I think omitting all the FileScan operators from this list was an oversight; at any rate this is causing duplicate output whenever a query with a FileScan source is run on a cluster with more than one worker. Not sure if there are any potential gotchas; @mbalazin mentioned that one of the astronomy formats (Tipsy?) might have files with the same name on different workers with different contents, so I'd like to confirm if that is current usage.
