### PR TITLE
Setting bootclasspath for cross-compiling on Java 8.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -170,6 +170,18 @@ dependencies {
   testsuitesRuntime configurations.systemtestRuntime
 }
 
+/* If Java 8 is the default JDK but Java 7 is installed, do a proper cross-compile. */
+tasks.withType(JavaCompile) {
+  doFirst {
+    if (sourceCompatibility == '1.7' && System.env.JAVA7_HOME != null) {
+      options.fork = true
+      options.bootClasspath = "$System.env.JAVA7_HOME/jre/lib/rt.jar"
+      options.bootClasspath += "$File.pathSeparator$System.env.JAVA7_HOME/jre/lib/jsse.jar"
+      // use the line above as an example to add jce.jar and other specific JDK jars
+    }
+  }
+}
+
 /* Tell Java to emit all compiler warnings. */
 tasks.withType(JavaCompile) {
   options.compilerArgs << "-Xlint"


### PR DESCRIPTION
After compiling Myria binaries on my laptop with Java 8 installed, I got mysterious errors after deployment which turned out to be due to not setting the `-bootclasspath` option to` javac`. See this article for explanation: https://blogs.oracle.com/darcy/entry/how_to_cross_compile_for. To cross-compile correctly from a newer JDK version to an older one, it is not enough to set `-source` and `-target` options as we do currently; we also have to set the boot classpath (where the `javac` class loader looks for "bootstrap" libraries). With this change, to build Myria on a system with Java 8 installed, you must install JDK 7 and set the `JAVA7_HOME` environment variable to the location of your JDK. On a Mac, this can be done properly by adding the following to your `.zshenv` or `.bashrc`:
`export JAVA7_HOME=$(/usr/libexec/java_home -v 1.7)`