### PR TITLE
Add IntelliJ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ build
 *catalog-journal
 englink-log4j.log
 /bin
+
+### Intellij ###
+*.iml
+.idea/


### PR DESCRIPTION
These are auto-generated files by the IntelliJ IDE that should not be stored in git repositories.