### PR TITLE
Fixing deletion from catalog during overwrite.

### DIFF
--- a/src/edu/washington/escience/myria/coordinator/MasterCatalog.java
+++ b/src/edu/washington/escience/myria/coordinator/MasterCatalog.java
@@ -1358,12 +1358,11 @@ public final class MasterCatalog {
    * @throws CatalogException if there is an error
    */
   private void deleteRelationIfExists(@Nonnull final SQLiteConnection sqliteConnection,
-      @Nonnull final RelationKey relation, final boolean isOverwrite) throws CatalogException {
+      @Nonnull final RelationKey relation) throws CatalogException {
     try {
-      String sql =
-          String.format("DELETE FROM relations WHERE user_name=? AND program_name=? AND relation_name=? AND %s;",
-              (isOverwrite ? "1=1" : "is_deleted=1"));
-      SQLiteStatement statement = sqliteConnection.prepare(sql);
+      SQLiteStatement statement =
+          sqliteConnection
+              .prepare("DELETE FROM relations WHERE user_name=? AND program_name=? AND relation_name=? AND is_deleted=1;");
       statement.bind(1, relation.getUserName());
       statement.bind(2, relation.getProgramName());
       statement.bind(3, relation.getRelationName());
@@ -1393,7 +1392,7 @@ public final class MasterCatalog {
         protected Void job(final SQLiteConnection sqliteConnection) throws CatalogException, SQLiteException {
           sqliteConnection.exec("BEGIN TRANSACTION;");
           try {
-            deleteRelationIfExists(sqliteConnection, relationKey, false);
+            deleteRelationIfExists(sqliteConnection, relationKey);
             sqliteConnection.exec("COMMIT TRANSACTION;");
           } catch (SQLiteException e) {
             try {
@@ -1480,7 +1479,7 @@ public final class MasterCatalog {
               RelationKey relation = meta.getRelationKey();
               Set<Integer> workers = meta.getWorkers();
               if (meta.isOverwrite()) {
-                deleteRelationIfExists(sqliteConnection, meta.getRelationKey(), true);
+                deleteRelationIfExists(sqliteConnection, meta.getRelationKey());
               }
               Schema schema = meta.getSchema();
               if (meta.isOverwrite() || getSchema(sqliteConnection, relation) == null) {

--- a/src/edu/washington/escience/myria/coordinator/MasterCatalog.java
+++ b/src/edu/washington/escience/myria/coordinator/MasterCatalog.java
@@ -334,7 +334,7 @@ public final class MasterCatalog {
       /* First, insert the relation name. */
       SQLiteStatement statement =
           sqliteConnection
-              .prepare("INSERT INTO relations (user_name,program_name,relation_name,num_tuples,is_deleted,query_id) VALUES (?,?,?,?,?,?);");
+              .prepare("INSERT OR REPLACE INTO relations (user_name,program_name,relation_name,num_tuples,is_deleted,query_id) VALUES (?,?,?,?,?,?);");
       statement.bind(1, relation.getUserName());
       statement.bind(2, relation.getProgramName());
       statement.bind(3, relation.getRelationName());
@@ -348,7 +348,7 @@ public final class MasterCatalog {
       /* Second, populate the Schema table. */
       statement =
           sqliteConnection
-              .prepare("INSERT INTO relation_schema(user_name,program_name,relation_name,col_index,col_name,col_type) "
+              .prepare("INSERT OR REPLACE INTO relation_schema(user_name,program_name,relation_name,col_index,col_name,col_type) "
                   + "VALUES (?,?,?,?,?,?);");
       statement.bind(1, relation.getUserName());
       statement.bind(2, relation.getProgramName());
@@ -1478,9 +1478,6 @@ public final class MasterCatalog {
             for (RelationWriteMetadata meta : relationsCreated.values()) {
               RelationKey relation = meta.getRelationKey();
               Set<Integer> workers = meta.getWorkers();
-              if (meta.isOverwrite()) {
-                deleteRelationIfExists(sqliteConnection, meta.getRelationKey());
-              }
               Schema schema = meta.getSchema();
               if (meta.isOverwrite() || getSchema(sqliteConnection, relation) == null) {
                 /* Overwrite or new relation. */

--- a/src/edu/washington/escience/myria/coordinator/MasterCatalog.java
+++ b/src/edu/washington/escience/myria/coordinator/MasterCatalog.java
@@ -334,7 +334,7 @@ public final class MasterCatalog {
       /* First, insert the relation name. */
       SQLiteStatement statement =
           sqliteConnection
-              .prepare("INSERT OR REPLACE INTO relations (user_name,program_name,relation_name,num_tuples,is_deleted,query_id) VALUES (?,?,?,?,?,?);");
+              .prepare("INSERT INTO relations (user_name,program_name,relation_name,num_tuples,is_deleted,query_id) VALUES (?,?,?,?,?,?);");
       statement.bind(1, relation.getUserName());
       statement.bind(2, relation.getProgramName());
       statement.bind(3, relation.getRelationName());
@@ -348,7 +348,7 @@ public final class MasterCatalog {
       /* Second, populate the Schema table. */
       statement =
           sqliteConnection
-              .prepare("INSERT OR REPLACE INTO relation_schema(user_name,program_name,relation_name,col_index,col_name,col_type) "
+              .prepare("INSERT INTO relation_schema(user_name,program_name,relation_name,col_index,col_name,col_type) "
                   + "VALUES (?,?,?,?,?,?);");
       statement.bind(1, relation.getUserName());
       statement.bind(2, relation.getProgramName());
@@ -1478,6 +1478,9 @@ public final class MasterCatalog {
             for (RelationWriteMetadata meta : relationsCreated.values()) {
               RelationKey relation = meta.getRelationKey();
               Set<Integer> workers = meta.getWorkers();
+              if (meta.isOverwrite()) {
+                deleteRelationIfExists(sqliteConnection, meta.getRelationKey());
+              }
               Schema schema = meta.getSchema();
               if (meta.isOverwrite() || getSchema(sqliteConnection, relation) == null) {
                 /* Overwrite or new relation. */


### PR DESCRIPTION
I had to make this fix on the fly during deployment because all sample queries from myria-web were succeeding but would not show results. The issue was a design oversight in the "delete relation" code: it always checked for the `is_deleted` flag to be set before deleting a relation from the catalog, but that only makes sense if we're going through the deletion API. In the overwrite scenario we shouldn't check the flag at all before deleting the relation. 