### PR TITLE
add HTTP endpoint to restart cluster

### DIFF
--- a/src/edu/washington/escience/myria/api/MasterResource.java
+++ b/src/edu/washington/escience/myria/api/MasterResource.java
@@ -70,7 +70,7 @@ public final class MasterResource {
     shutdownThread.start();
   }
 
-  private static int getProcessPid() throws Exception {
+  private static int getProcessPid() {
     // HACK: in the Oracle JVM, we can get the current process's PID as the first component of the value returned by
     // ManagementFactory.getRuntimeMXBean().getName().
     // This method is documented "Returns the name representing the running Java virtual machine."
@@ -79,7 +79,7 @@ public final class MasterResource {
     if (pidStr.contains("@")) {
       return Integer.parseInt(pidStr.split("@")[0]);
     } else {
-      throw new Exception("Cannot find pid from string: " + pidStr);
+      throw new RuntimeException("Cannot find pid from string: " + pidStr);
     }
   }
 
@@ -98,12 +98,12 @@ public final class MasterResource {
    * 
    * @param server the Myria {@link Server} to be restarted.
    * @return a success message.
-   * @throws Exception
+   * @throws ConfigFileException
    */
   @GET
   @Path("/restart")
   @ADMIN
-  public Response restart(@Context final MasterDaemon daemon) throws Exception {
+  public Response restart(@Context final MasterDaemon daemon) throws ConfigFileException {
     String workingDir = daemon.getClusterMaster().getConfig().getWorkingDirectory(MyriaConstants.MASTER_ID);
     String deploymentFile = FilenameUtils.concat(workingDir, MyriaConstants.DEPLOYMENT_CONF_FILE);
     int pid = getProcessPid();

--- a/src/edu/washington/escience/myria/api/MasterResource.java
+++ b/src/edu/washington/escience/myria/api/MasterResource.java
@@ -1,5 +1,9 @@
 package edu.washington.escience.myria.api;
 
+import java.lang.management.ManagementFactory;
+import java.util.ArrayList;
+import java.util.List;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -7,6 +11,10 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 
 import org.apache.commons.io.FilenameUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Joiner;
 
 import edu.washington.escience.myria.MyriaConstants;
 import edu.washington.escience.myria.api.MasterApplication.ADMIN;
@@ -14,6 +22,7 @@ import edu.washington.escience.myria.api.encoding.VersionEncoding;
 import edu.washington.escience.myria.coordinator.ConfigFileException;
 import edu.washington.escience.myria.daemon.MasterDaemon;
 import edu.washington.escience.myria.parallel.Server;
+import edu.washington.escience.myria.util.DeploymentUtils;
 
 /**
  * This is the class that handles API calls that return workers.
@@ -22,6 +31,10 @@ import edu.washington.escience.myria.parallel.Server;
  */
 @Path("/server")
 public final class MasterResource {
+
+  /** The logger for this class. */
+  private static final Logger LOGGER = LoggerFactory.getLogger(MasterResource.class);
+
   /** How long the thread should sleep before shutting down the daemon. This is a HACK! TODO */
   private static final int SLEEP_BEFORE_SHUTDOWN_MS = 100;
 
@@ -35,6 +48,11 @@ public final class MasterResource {
   @Path("/shutdown")
   @ADMIN
   public Response shutdown(@Context final MasterDaemon daemon) {
+    doShutdown(daemon);
+    return Response.ok("Success").build();
+  }
+
+  private static void doShutdown(final MasterDaemon daemon) {
     /* A thread to stop the daemon after this request finishes. */
     Thread shutdownThread = new Thread("MasterResource-Shutdown") {
       @Override
@@ -50,6 +68,59 @@ public final class MasterResource {
 
     /* Start the thread, then return an empty success response. */
     shutdownThread.start();
+  }
+
+  private static int getProcessPid() throws Exception {
+    // HACK: in the Oracle JVM, we can get the current process's PID as the first component of the value returned by
+    // ManagementFactory.getRuntimeMXBean().getName().
+    // This method is documented "Returns the name representing the running Java virtual machine."
+    // Example: "742912@localhost"
+    String pidStr = ManagementFactory.getRuntimeMXBean().getName();
+    if (pidStr.contains("@")) {
+      return Integer.parseInt(pidStr.split("@")[0]);
+    } else {
+      throw new Exception("Cannot find pid from string: " + pidStr);
+    }
+  }
+
+  // NB: this is superseded by Process.isAlive() in Java 8
+  private static boolean isAlive(final Process p) {
+    try {
+      p.exitValue();
+      return false;
+    } catch (IllegalThreadStateException e) {
+      return true;
+    }
+  }
+
+  /**
+   * Restart the server.
+   * 
+   * @param server the Myria {@link Server} to be restarted.
+   * @return a success message.
+   * @throws Exception
+   */
+  @GET
+  @Path("/restart")
+  @ADMIN
+  public Response restart(@Context final MasterDaemon daemon) throws Exception {
+    String workingDir = daemon.getClusterMaster().getConfig().getWorkingDirectory(MyriaConstants.MASTER_ID);
+    String deploymentFile = FilenameUtils.concat(workingDir, MyriaConstants.DEPLOYMENT_CONF_FILE);
+    int pid = getProcessPid();
+    String classpath = String.format("'%s/conf:%s/libs/*'", workingDir, workingDir);
+    String command =
+        String.format("java -cp %s edu.washington.escience.myria.util.MyriaLauncher %s %s", classpath, deploymentFile,
+            Integer.toString(pid));
+    List<String> args = new ArrayList<>();
+    // HACK: If we launch the java process directly, then for some reason the child process exits as soon as the parent
+    // exits (even if we don't inherit open file descriptors).
+    args.add("/bin/sh");
+    args.add("-c");
+    args.add(command);
+    LOGGER.debug("Command line for MyriaLauncher:\n{}", Joiner.on(" ").join(args));
+    Process p = DeploymentUtils.startAProcess(args.toArray(new String[args.size()]), false, false);
+    doShutdown(daemon);
+    LOGGER.debug("MyriaLauncher alive: {}", isAlive(p));
     return Response.ok("Success").build();
   }
 

--- a/src/edu/washington/escience/myria/util/DeploymentUtils.java
+++ b/src/edu/washington/escience/myria/util/DeploymentUtils.java
@@ -415,8 +415,18 @@ public final class DeploymentUtils {
    * 
    * @param cmd cmd[0] is the command name, from cmd[1] are arguments.
    */
-  private static void startAProcess(final String[] cmd) {
-    startAProcess(cmd, true);
+  public static Process startAProcess(final String[] cmd) {
+    return startAProcess(cmd, true, true);
+  }
+
+  /**
+   * start a process by ProcessBuilder, wait for the process to finish.
+   * 
+   * @param cmd cmd[0] is the command name, from cmd[1] are arguments.
+   * @param waitFor do we wait for the process to finish.
+   */
+  public static Process startAProcess(final String[] cmd, final boolean waitFor) {
+    return startAProcess(cmd, waitFor, true);
   }
 
   /**
@@ -424,11 +434,17 @@ public final class DeploymentUtils {
    * 
    * @param cmd cmd[0] is the command name, from cmd[1] are arguments.
    * @param waitFor do we wait for the process to finish.
+   * @param inheritIO inherit all file descriptors from the parent process.
    */
-  private static void startAProcess(final String[] cmd, final boolean waitFor) {
+  public static Process startAProcess(final String[] cmd, final boolean waitFor, final boolean inheritIO) {
     LOGGER.debug(StringUtils.join(cmd, " "));
+    Process p;
     try {
-      Process p = new ProcessBuilder().inheritIO().command(cmd).start();
+      if (inheritIO) {
+        p = new ProcessBuilder().inheritIO().command(cmd).start();
+      } else {
+        p = new ProcessBuilder().command(cmd).start();
+      }
       if (waitFor) {
         int ret = p.waitFor();
         if (ret != 0) {
@@ -439,6 +455,7 @@ public final class DeploymentUtils {
       e.printStackTrace();
       throw new RuntimeException(e);
     }
+    return p;
   }
 
   /**

--- a/src/edu/washington/escience/myria/util/MyriaLauncher.java
+++ b/src/edu/washington/escience/myria/util/MyriaLauncher.java
@@ -1,0 +1,51 @@
+package edu.washington.escience.myria.util;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import edu.washington.escience.myria.coordinator.CatalogException;
+import edu.washington.escience.myria.coordinator.ConfigFileException;
+
+public class MyriaLauncher {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(MyriaLauncher.class);
+
+  public static void main(final String[] args) throws ConfigFileException, CatalogException, IOException,
+      InterruptedException {
+    LOGGER.debug("MyriaLauncher started with args {}, {}", args[0], args[1]);
+    final String deploymentFile = args[0];
+    final int oldPid = Integer.parseInt(args[1]);
+    pollForExit(oldPid);
+    DeploymentUtils.main(new String[] { deploymentFile, "--start-master" });
+    DeploymentUtils.main(new String[] { deploymentFile, "--start-workers" });
+  }
+
+  private static void pollForExit(final int pidToExit) throws IOException, InterruptedException {
+    boolean pidRunning;
+    do {
+      pidRunning = false;
+      ProcessBuilder pb = new ProcessBuilder("ps", "-A");
+      Process p = pb.start();
+      BufferedReader in = new BufferedReader(new InputStreamReader(p.getInputStream()));
+      // Skip first (header) line: "  PID TTY          TIME CMD"
+      in.readLine();
+      // Extract process IDs from lines of output
+      // e.g. "  146 ?        00:03:45 pdflush"
+      for (String line = in.readLine(); line != null; line = in.readLine()) {
+        int currentPid = Integer.parseInt(line.trim().split("\\s+")[0]);
+        if (currentPid == pidToExit) {
+          LOGGER.debug("Process {} still running", currentPid);
+          pidRunning = true;
+          break;
+        }
+      }
+      if (pidRunning) {
+        Thread.sleep(1000);
+      }
+    } while (pidRunning);
+  }
+}


### PR DESCRIPTION
Fixes #789 

Sample usage: `curl -i localhost:8753/server/restart`

I didn't add tests because this is just a stopgap measure until the `reef` branch is operational, but I have tested it manually.