### PR TITLE
make JVM exit when OOM

### DIFF
--- a/src/edu/washington/escience/myria/util/JVMUtils.java
+++ b/src/edu/washington/escience/myria/util/JVMUtils.java
@@ -4,12 +4,19 @@ package edu.washington.escience.myria.util;
  * JVM util methods.
  */
 public final class JVMUtils {
+  /** The logger for this class. */
+  private static final org.slf4j.Logger LOGGER = org.slf4j.LoggerFactory.getLogger(JVMUtils.class);
 
   /**
    * Shutdown the java virtual machine.
    */
   public static void shutdownVM() {
     System.exit(0);
+  }
+
+  public static void shutdownVM(final Throwable e) {
+    LOGGER.error("System will exit due to " + e);
+    System.exit(1);
   }
 
   /**

--- a/src/edu/washington/escience/myria/util/concurrent/ErrorLoggingTimerTask.java
+++ b/src/edu/washington/escience/myria/util/concurrent/ErrorLoggingTimerTask.java
@@ -3,6 +3,8 @@ package edu.washington.escience.myria.util.concurrent;
 import java.util.TimerTask;
 import java.util.concurrent.ScheduledExecutorService;
 
+import edu.washington.escience.myria.util.JVMUtils;
+
 /**
  * The Java {@link ScheduledExecutorService} suppress the subsequent execution of a {@link TimerTask} if any execution
  * of the task encounters an exception. This class captures all {@link Throwable}s and logs them. And all
@@ -35,7 +37,12 @@ public abstract class ErrorLoggingTimerTask extends TimerTask {
       if (e instanceof InterruptedException) {
         Thread.currentThread().interrupt();
       } else if (e instanceof Error) {
+        if (e instanceof OutOfMemoryError) {
+          JVMUtils.shutdownVM(e);
+        }
         throw (Error) e;
+      } else if (e instanceof RuntimeException) {
+        throw (RuntimeException) e;
       }
     }
   }

--- a/src/edu/washington/escience/myria/util/concurrent/ExecutableExecutionFuture.java
+++ b/src/edu/washington/escience/myria/util/concurrent/ExecutableExecutionFuture.java
@@ -10,6 +10,7 @@ import java.util.concurrent.TimeoutException;
 import com.google.common.base.Preconditions;
 
 import edu.washington.escience.myria.DbException;
+import edu.washington.escience.myria.util.JVMUtils;
 
 /**
  * The {@link ExecutionFuture} implementation that is Callable and Runnable. The state of the future is set
@@ -210,6 +211,9 @@ public class ExecutableExecutionFuture<T> extends OperationFutureBase<T> impleme
       }
     } catch (Throwable e) {
       setFailure0(e);
+      if (e instanceof OutOfMemoryError) {
+        JVMUtils.shutdownVM(e);
+      }
       if (e instanceof Exception) {
         throw e;
       }

--- a/src/edu/washington/escience/myria/util/concurrent/OperationFutureBase.java
+++ b/src/edu/washington/escience/myria/util/concurrent/OperationFutureBase.java
@@ -581,10 +581,13 @@ public abstract class OperationFutureBase<T> implements OperationFuture {
   private void notifyListener(final OperationFutureListener l) {
     try {
       l.operationComplete(this);
-    } catch (Throwable t) {
+    } catch (Exception t) {
       if (LOGGER.isWarnEnabled()) {
         LOGGER.warn("An exception was thrown by " + OperationFutureListener.class.getSimpleName() + '.', t);
       }
+    } catch (Throwable t) {
+      LOGGER.info("A throwable was thrown by " + OperationFutureListener.class.getSimpleName() + '.', t);
+      throw t;
     }
   }
 }

--- a/src/edu/washington/escience/myria/util/concurrent/RenamingThreadFactory.java
+++ b/src/edu/washington/escience/myria/util/concurrent/RenamingThreadFactory.java
@@ -34,5 +34,4 @@ public class RenamingThreadFactory implements ThreadFactory {
       }
     };
   }
-
 }


### PR DESCRIPTION
When the JVM is close to an OOM state, the OOM error can be thrown at any time by any thread, even threads that are not used for query processing. The old implementation takes a long way to propagate an OOM error from the lowest level to Worker level, and the system state can crash during this process so that the query is still marked as running but the JVM cannot respond anymore. On the other hand, it is unnecessary to clean up after an OOM since the JVM is in an OOM state anyway. So we terminate the worker process when an OOM is detected.