### PR TITLE
Rename import

### DIFF
--- a/src/edu/washington/escience/myria/api/DatasetResource.java
+++ b/src/edu/washington/escience/myria/api/DatasetResource.java
@@ -492,15 +492,15 @@ public final class DatasetResource {
   }
 
   /**
-   * @param dataset the dataset to be imported.
+   * @param dataset the dataset to be added.
    * @param uriInfo information about the current URL.
    * @return created dataset resource.
    * @throws DbException if there is an error in the database.
    */
   @POST
-  @Path("/importDataset")
+  @Path("/addDatasetToCatalog")
   @Consumes(MediaType.APPLICATION_JSON)
-  public Response importDataset(final DatasetEncoding dataset, @Context final UriInfo uriInfo) throws DbException {
+  public Response addDatasetToCatalog(final DatasetEncoding dataset, @Context final UriInfo uriInfo) throws DbException {
 
     /* If we already have a dataset by this name, tell the user there's a conflict. */
     try {
@@ -512,14 +512,14 @@ public final class DatasetResource {
       throw new DbException(e);
     }
 
-    /* For import, force the user to supply the workers. */
+    /* When adding a dataset to the catalog, force the user to supply the workers. */
     if (dataset.workers == null) {
       throw new MyriaApiException(Status.BAD_REQUEST,
-          "When importing, you need to specify which workers have the dataset.");
+          "When adding a dataset to the catalog, you need to specify which workers have the dataset.");
     }
 
     try {
-      server.importDataset(dataset.relationKey, dataset.schema, dataset.workers);
+      server.addDatasetToCatalog(dataset.relationKey, dataset.schema, dataset.workers);
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
     }

--- a/src/edu/washington/escience/myria/parallel/Server.java
+++ b/src/edu/washington/escience/myria/parallel/Server.java
@@ -988,14 +988,14 @@ public final class Server {
   }
 
   /**
-   * @param relationKey the relationalKey of the dataset to import
-   * @param schema the schema of the dataset to import
+   * @param relationKey the relationalKey of the dataset to add
+   * @param schema the schema of the dataset to add
    * @param workersToImportFrom the set of workers
    * @throws DbException if there is an error
    * @throws InterruptedException interrupted
    */
-  public void importDataset(final RelationKey relationKey, final Schema schema, final Set<Integer> workersToImportFrom)
-      throws DbException, InterruptedException {
+  public void addDatasetToCatalog(final RelationKey relationKey, final Schema schema,
+      final Set<Integer> workersToImportFrom) throws DbException, InterruptedException {
 
     /* Figure out the workers we will use. If workersToImportFrom is null, use all active workers. */
     Set<Integer> actualWorkers = workersToImportFrom;
@@ -1011,8 +1011,9 @@ public final class Server {
         workerPlans.put(workerId, new SubQueryPlan(new DbInsert(EmptyRelation.of(schema), relationKey, false)));
       }
       ListenableFuture<Query> qf =
-          queryManager.submitQuery("import " + relationKey.toString(), "import " + relationKey.toString(), "import "
-              + relationKey.toString(getDBMS()), new SubQueryPlan(new SinkRoot(new EOSSource())), workerPlans);
+          queryManager.submitQuery("add to catalog " + relationKey.toString(), "add to catalog "
+              + relationKey.toString(), "add to catalog " + relationKey.toString(getDBMS()), new SubQueryPlan(
+              new SinkRoot(new EOSSource())), workerPlans);
       try {
         qf.get();
       } catch (ExecutionException e) {

--- a/systemtest/edu/washington/escience/myria/systemtest/MultiwayJoinTest.java
+++ b/systemtest/edu/washington/escience/myria/systemtest/MultiwayJoinTest.java
@@ -53,9 +53,9 @@ public class MultiwayJoinTest extends SystemTestBase {
     /* Step 1: generate test data */
     final HashMap<Tuple, Integer> expectedResult = simpleRandomJoinTestBase();
 
-    server.importDataset(JOIN_TEST_TABLE_1, JOIN_INPUT_SCHEMA, new HashSet<Integer>(Arrays.asList(workerIDs[0],
+    server.addDatasetToCatalog(JOIN_TEST_TABLE_1, JOIN_INPUT_SCHEMA, new HashSet<Integer>(Arrays.asList(workerIDs[0],
         workerIDs[1])));
-    server.importDataset(JOIN_TEST_TABLE_2, JOIN_INPUT_SCHEMA, new HashSet<Integer>(Arrays.asList(workerIDs[0],
+    server.addDatasetToCatalog(JOIN_TEST_TABLE_2, JOIN_INPUT_SCHEMA, new HashSet<Integer>(Arrays.asList(workerIDs[0],
         workerIDs[1])));
 
     /* Step 2: submit JSON query plan */
@@ -180,9 +180,9 @@ public class MultiwayJoinTest extends SystemTestBase {
     }
 
     /* import dataset to catalog */
-    server.importDataset(JOIN_TEST_TABLE_1, JOIN_INPUT_SCHEMA, new HashSet<Integer>(Arrays.asList(workerIDs[0],
+    server.addDatasetToCatalog(JOIN_TEST_TABLE_1, JOIN_INPUT_SCHEMA, new HashSet<Integer>(Arrays.asList(workerIDs[0],
         workerIDs[1])));
-    server.importDataset(JOIN_TEST_TABLE_2, JOIN_INPUT_SCHEMA, new HashSet<Integer>(Arrays.asList(workerIDs[0],
+    server.addDatasetToCatalog(JOIN_TEST_TABLE_2, JOIN_INPUT_SCHEMA, new HashSet<Integer>(Arrays.asList(workerIDs[0],
         workerIDs[1])));
 
     /* Step 2: do the query */


### PR DESCRIPTION
Initially mentioned on issue #820. During the last meeting we discussed how this special case does not fit well with the new import refactoring using DataInput. 

Else if we still want to make this work with DataInput, we can always just push this renaming PR first and then refactor it later when fixing for #810 ?