### PR TITLE
Binary ingest support for Booleans and Strings

### DIFF
--- a/src/edu/washington/escience/myria/operator/BinaryFileScan.java
+++ b/src/edu/washington/escience/myria/operator/BinaryFileScan.java
@@ -91,7 +91,7 @@ public class BinaryFileScan extends LeafOperator {
               break;
             default:
               throw new UnsupportedOperationException(
-                  "BinaryFileScan does not support the type "+schema.getColumnType(count));
+                  "BinaryFileScan does not support the type " + schema.getColumnType(count));
           }
           building = true;
         }

--- a/src/edu/washington/escience/myria/operator/BinaryFileScan.java
+++ b/src/edu/washington/escience/myria/operator/BinaryFileScan.java
@@ -1,5 +1,13 @@
 package edu.washington.escience.myria.operator;
 
+import com.google.common.collect.ImmutableMap;
+import com.google.common.io.LittleEndianDataInputStream;
+import edu.washington.escience.myria.DbException;
+import edu.washington.escience.myria.Schema;
+import edu.washington.escience.myria.io.DataSource;
+import edu.washington.escience.myria.storage.TupleBatch;
+import edu.washington.escience.myria.storage.TupleBatchBuffer;
+
 import java.io.BufferedInputStream;
 import java.io.DataInput;
 import java.io.DataInputStream;
@@ -8,15 +16,6 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Objects;
-
-import com.google.common.collect.ImmutableMap;
-import com.google.common.io.LittleEndianDataInputStream;
-
-import edu.washington.escience.myria.DbException;
-import edu.washington.escience.myria.Schema;
-import edu.washington.escience.myria.io.DataSource;
-import edu.washington.escience.myria.storage.TupleBatch;
-import edu.washington.escience.myria.storage.TupleBatchBuffer;
 
 /**
  * Reads data from binary file. This class is written base on the code from FileScan.java
@@ -72,23 +71,27 @@ public class BinaryFileScan extends LeafOperator {
       while (buffer.numTuples() < TupleBatch.BATCH_SIZE) {
         for (int count = 0; count < schema.numColumns(); ++count) {
           switch (schema.getColumnType(count)) {
+            case BOOLEAN_TYPE:
+              buffer.putBoolean(count, dataInput.readBoolean());
+              break;
             case DOUBLE_TYPE:
               buffer.putDouble(count, dataInput.readDouble());
               break;
             case FLOAT_TYPE:
-              float readFloat = dataInput.readFloat();
-              buffer.putFloat(count, readFloat);
+              buffer.putFloat(count, dataInput.readFloat());
               break;
             case INT_TYPE:
               buffer.putInt(count, dataInput.readInt());
               break;
             case LONG_TYPE:
-              long readLong = dataInput.readLong();
-              buffer.putLong(count, readLong);
+              buffer.putLong(count, dataInput.readLong());
+              break;
+            case STRING_TYPE:
+              buffer.putString(count, dataInput.readUTF());
               break;
             default:
               throw new UnsupportedOperationException(
-                  "BinaryFileScan only support reading fixed width type from the binary file.");
+                  "BinaryFileScan does not support the type "+schema.getColumnType(count));
           }
           building = true;
         }

--- a/src/edu/washington/escience/myria/operator/FileScan.java
+++ b/src/edu/washington/escience/myria/operator/FileScan.java
@@ -206,8 +206,7 @@ public final class FileScan extends LeafOperator {
           switch (schema.getColumnType(column)) {
             case BOOLEAN_TYPE:
               Float f = Floats.tryParse(cell);
-              if (f != null)
-                buffer.putBoolean(column, f != 0);
+              if (f != null) buffer.putBoolean(column, f != 0);
               else if (BooleanUtils.toBoolean(cell))
                 buffer.putBoolean(column, Boolean.parseBoolean(cell));
               break;

--- a/src/edu/washington/escience/myria/operator/FileScan.java
+++ b/src/edu/washington/escience/myria/operator/FileScan.java
@@ -1,22 +1,9 @@
 package edu.washington.escience.myria.operator;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.util.Iterator;
-
-import javax.annotation.Nullable;
-
-import org.apache.commons.csv.CSVFormat;
-import org.apache.commons.csv.CSVParser;
-import org.apache.commons.csv.CSVRecord;
-import org.apache.commons.lang.BooleanUtils;
-
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.primitives.Floats;
-
 import edu.washington.escience.myria.DbException;
 import edu.washington.escience.myria.Schema;
 import edu.washington.escience.myria.io.DataSource;
@@ -24,6 +11,16 @@ import edu.washington.escience.myria.io.FileSource;
 import edu.washington.escience.myria.storage.TupleBatch;
 import edu.washington.escience.myria.storage.TupleBatchBuffer;
 import edu.washington.escience.myria.util.DateTimeUtils;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVRecord;
+import org.apache.commons.lang.BooleanUtils;
+
+import javax.annotation.Nullable;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Iterator;
 
 /**
  * Reads data from a file. For CSV files, the default parser follows the RFC 4180 (http://tools.ietf.org/html/rfc4180).
@@ -208,11 +205,11 @@ public final class FileScan extends LeafOperator {
         try {
           switch (schema.getColumnType(column)) {
             case BOOLEAN_TYPE:
-              if (Floats.tryParse(cell) != null) {
-                buffer.putBoolean(column, Floats.tryParse(cell) != 0);
-              } else if (BooleanUtils.toBoolean(cell)) {
+              Float f = Floats.tryParse(cell);
+              if (f != null)
+                buffer.putBoolean(column, f != 0);
+              else if (BooleanUtils.toBoolean(cell))
                 buffer.putBoolean(column, Boolean.parseBoolean(cell));
-              }
               break;
             case DOUBLE_TYPE:
               buffer.putDouble(column, Double.parseDouble(cell));

--- a/test/edu/washington/escience/myria/operator/BinaryFileScanTest.java
+++ b/test/edu/washington/escience/myria/operator/BinaryFileScanTest.java
@@ -112,10 +112,15 @@ public class BinaryFileScanTest {
 
   @Test
   public void testGenerateReadBinary() throws Exception {
-    Schema schema = new Schema(ImmutableList.of(  // one of each
-        Type.BOOLEAN_TYPE, Type.DOUBLE_TYPE, Type.FLOAT_TYPE, Type.INT_TYPE,
-        Type.LONG_TYPE, Type.STRING_TYPE
-    ));
+    Schema schema =
+        new Schema(
+            ImmutableList.of( // one of each
+                Type.BOOLEAN_TYPE,
+                Type.DOUBLE_TYPE,
+                Type.FLOAT_TYPE,
+                Type.INT_TYPE,
+                Type.LONG_TYPE,
+                Type.STRING_TYPE));
     byte[] buf;
     {
       ByteArrayOutputStream bos = new ByteArrayOutputStream(1000);
@@ -147,7 +152,8 @@ public class BinaryFileScanTest {
    * @param stream The data stream to write data to. Does not close the stream.
    */
   @SuppressWarnings("unused")
-  private void generateBinaryData(DataOutputStream stream, Type[] typeAr, int numrows) throws IOException {
+  private void generateBinaryData(DataOutputStream stream, Type[] typeAr, int numrows)
+      throws IOException {
     for (int i = 0; i < numrows; i++) {
       for (Type element : typeAr) {
         switch (element) {
@@ -167,11 +173,10 @@ public class BinaryFileScanTest {
             stream.writeLong(i);
             break;
           case STRING_TYPE:
-            stream.writeUTF("string"+i);
+            stream.writeUTF("string" + i);
             break;
           default:
-            throw new UnsupportedOperationException(
-                "can only write fix length field to bin file");
+            throw new UnsupportedOperationException("can only write fix length field to bin file");
         }
       }
     }


### PR DESCRIPTION
This enables support for binary ingest of data with schema containing BOOLEAN or STRING types. The String encoding is variable-width; it reads the length of the string, then the string itself, as expected from `DataOutputStream.readUTF()`.