### PR TITLE
parallel ingest bug fix

### DIFF
--- a/src/edu/washington/escience/myria/operator/CSVFileScanFragment.java
+++ b/src/edu/washington/escience/myria/operator/CSVFileScanFragment.java
@@ -433,6 +433,7 @@ public class CSVFileScanFragment extends LeafOperator {
         }
       }
 
+      /* If we hit the end of the partition then mark it as incomplete.*/
       if (adjustedStartByteRange + byteOffsetFromTruncatedRowAtStart - 1 == partitionEndByteRange) {
         flagAsIncomplete = true;
       }
@@ -445,7 +446,7 @@ public class CSVFileScanFragment extends LeafOperator {
                 CSVFormat.newFormat(delimiter).withQuote(quote).withEscape(escape));
         iterator = parser.iterator();
 
-        /* FIX ME: For now, we only support cases where the numberOfSkippedLines applies to the first worker */
+        /* FIX ME: For now, we only support cases where all skipped lines are contained within the first partition. */
         if (partitionStartByteRange == 0) {
           for (int i = 0; i < numberOfSkippedLines; i++) {
             iterator.next();


### PR DESCRIPTION
@parmitam  was our first tester and ran into a bug. I realized I forgot to test the last changes we made for more than 2 workers. 

With this fix, I tested for 3 and 5 workers by temporarily adding workers to the SystemTestBase class.

Two fixes:

1) I added a global variable ```byteOffsetFromTruncatedRowAtStart``` which keeps track of the number of bytes we read when skipping over the first partial row. This variable becomes important in cases when a worker needs to reinitialize the parser -- we must have the correct offset otherwise our character skipping will be incorrect. Our 2-worker tests did not cover this because worker 1 never has to worry about this offset when reinitializing the parser (it is always going to be 0) and worker 2 is the last worker so it doesn't need to reinitialize the parser for the last row.

2) This other problem is more subtle. There might be a case when a worker has a partition such as "this_is_an_incomplete_row\n". Our code will read up to the new line ('\n') but we don't have a way to check if there are any other lines to read after that. So I added a way to check if there is something to read. If there isn't, the row is marked as ```flagAsIncomplete```. Here, we still need to check for the quote try/catch in cases as well.