### PR TITLE
encoding for DataOutput operator

### DIFF
--- a/src/edu/washington/escience/myria/TupleWriter.java
+++ b/src/edu/washington/escience/myria/TupleWriter.java
@@ -33,7 +33,7 @@ import edu.washington.escience.myria.storage.ReadableTable;
 )
 @JsonSubTypes({
   @Type(name = "CSV", value = CsvTupleWriter.class),
-  @Type(name = "Json", value = JsonTupleWriter.class),
+  @Type(name = "JSON", value = JsonTupleWriter.class),
   @Type(name = "PostgresBinary", value = PostgresBinaryTupleWriter.class)
 })
 public interface TupleWriter extends Serializable {

--- a/src/edu/washington/escience/myria/TupleWriter.java
+++ b/src/edu/washington/escience/myria/TupleWriter.java
@@ -5,6 +5,10 @@ import java.io.OutputStream;
 import java.io.Serializable;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
 import edu.washington.escience.myria.storage.ReadableTable;
 
 /**
@@ -22,6 +26,16 @@ import edu.washington.escience.myria.storage.ReadableTable;
  *
  *
  */
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "writerType"
+)
+@JsonSubTypes({
+  @Type(name = "CSV", value = CsvTupleWriter.class),
+  @Type(name = "Json", value = JsonTupleWriter.class),
+  @Type(name = "PostgresBinary", value = PostgresBinaryTupleWriter.class)
+})
 public interface TupleWriter extends Serializable {
   /**
    * This will initialize the {@link TupleWriter} {@link java.io.OutputStream}.

--- a/src/edu/washington/escience/myria/api/encoding/DataOutputEncoding.java
+++ b/src/edu/washington/escience/myria/api/encoding/DataOutputEncoding.java
@@ -1,0 +1,16 @@
+package edu.washington.escience.myria.api.encoding;
+
+import edu.washington.escience.myria.TupleWriter;
+import edu.washington.escience.myria.api.encoding.QueryConstruct.ConstructArgs;
+import edu.washington.escience.myria.io.DataSink;
+import edu.washington.escience.myria.operator.DataOutput;
+
+public class DataOutputEncoding extends UnaryOperatorEncoding<DataOutput> {
+  @Required public TupleWriter tupleWriter;
+  @Required public DataSink dataSink;
+
+  @Override
+  public DataOutput construct(ConstructArgs args) {
+    return new DataOutput(null, tupleWriter, dataSink);
+  }
+}

--- a/src/edu/washington/escience/myria/api/encoding/OperatorEncoding.java
+++ b/src/edu/washington/escience/myria/api/encoding/OperatorEncoding.java
@@ -31,6 +31,7 @@ import edu.washington.escience.myria.operator.Operator;
   @Type(name = "CollectProducer", value = CollectProducerEncoding.class),
   @Type(name = "Consumer", value = ConsumerEncoding.class),
   @Type(name = "Counter", value = CounterEncoding.class),
+  @Type(name = "DataOutput", value = DataOutputEncoding.class),
   @Type(name = "DbInsert", value = DbInsertEncoding.class),
   @Type(name = "DbQueryScan", value = QueryScanEncoding.class),
   @Type(name = "DbCreateIndex", value = CreateIndexEncoding.class),

--- a/src/edu/washington/escience/myria/io/DataSink.java
+++ b/src/edu/washington/escience/myria/io/DataSink.java
@@ -15,7 +15,8 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "dataType")
 @JsonSubTypes({
   @Type(name = "Pipe", value = PipeSink.class),
-  @Type(name = "Bytes", value = ByteSink.class)
+  @Type(name = "Bytes", value = ByteSink.class),
+  @Type(name = "Uri", value = UriSink.class)
 })
 public interface DataSink extends Serializable {
   /**


### PR DESCRIPTION
Currently, there's no way to encode the DataOutput operator. We were also missing JSON subtype annotation for UriSink and for the different types of supported TupleWriters. 