### PR TITLE
driverDir CLI; revamp CLI usage printing

### DIFF
--- a/src/edu/washington/escience/myria/daemon/MyriaDriverLauncher.java
+++ b/src/edu/washington/escience/myria/daemon/MyriaDriverLauncher.java
@@ -250,11 +250,11 @@ public final class MyriaDriverLauncher {
 
                   final StringBuilder sb = new StringBuilder(simpleName);
                   if (!shortName.isEmpty()) {
-                    sb.append(" [-").append(shortName).append("]");
+                    sb.append(String.format(" [-%s]", shortName));
                   }
                   // If desired, the type of the parameter can be obtained from
                   // commandLineConf.getNamedParameters() --> .getSimpleArgName()
-                  sb.append(": ").append(doc).append("\n -> ");
+                  sb.append(String.format(": %s\n-> ", doc));
 
                   boolean ok;
                   try {
@@ -266,9 +266,11 @@ public final class MyriaDriverLauncher {
                     ok = false;
                   }
                   if (!ok) {
-                    if (!defaultVal.isEmpty())
+                    if (!defaultVal.isEmpty()) {
                       sb.append("[cannot parse; using default] ").append(defaultVal);
-                    else sb.append("[cannot parse; no default]");
+                    } else {
+                      sb.append("[cannot parse; no default]");
+                    }
                   }
                   return sb.toString();
                 })

--- a/src/edu/washington/escience/myria/daemon/MyriaDriverLauncher.java
+++ b/src/edu/washington/escience/myria/daemon/MyriaDriverLauncher.java
@@ -222,30 +222,25 @@ public final class MyriaDriverLauncher {
             .map(
                 c -> {
                   final NamedParameter annotation = c.getAnnotation(NamedParameter.class);
-
                   final String fullName = c.getName();
                   final String simpleName = c.getSimpleName();
                   final String shortName = annotation.short_name();
                   final String doc = annotation.doc();
                   final String defaultVal;
-                  {
-                    if (!annotation
-                        .default_value()
-                        .equals(NamedParameter.REEF_UNINITIALIZED_VALUE)) {
-                      defaultVal = annotation.default_value();
-                    } else if (!annotation.default_class().equals(Void.class)) {
-                      defaultVal = annotation.default_class().getSimpleName();
-                    } else if (annotation.default_values().length > 0) {
-                      defaultVal = Arrays.toString(annotation.default_values());
-                    } else if (annotation.default_classes().length > 0) {
-                      final String classNames =
-                          Arrays.stream(annotation.default_classes())
-                              .map(Class::getSimpleName)
-                              .reduce("", (a, b) -> a + ", " + b);
-                      defaultVal = String.format("[%s]", classNames);
-                    } else {
-                      defaultVal = "";
-                    }
+                  if (!annotation.default_value().equals(NamedParameter.REEF_UNINITIALIZED_VALUE)) {
+                    defaultVal = annotation.default_value();
+                  } else if (!annotation.default_class().equals(Void.class)) {
+                    defaultVal = annotation.default_class().getSimpleName();
+                  } else if (annotation.default_values().length > 0) {
+                    defaultVal = Arrays.toString(annotation.default_values());
+                  } else if (annotation.default_classes().length > 0) {
+                    final String classNames =
+                        Arrays.stream(annotation.default_classes())
+                            .map(Class::getSimpleName)
+                            .reduce("", (a, b) -> a + ", " + b);
+                    defaultVal = String.format("[%s]", classNames);
+                  } else {
+                    defaultVal = "";
                   }
 
                   final StringBuilder sb = new StringBuilder(simpleName);
@@ -314,7 +309,6 @@ public final class MyriaDriverLauncher {
       final String configPath = commandLineInjector.getNamedInstance(ConfigPath.class);
       final String javaLibPath = commandLineInjector.getNamedInstance(JavaLibPath.class);
       final String nativeLibPath = commandLineInjector.getNamedInstance(NativeLibPath.class);
-
       final Configuration globalConf = getMyriaGlobalConf(configPath);
       final String serializedGlobalConf = new AvroConfigurationSerializer().toString(globalConf);
       final Configuration globalConfWrapper =

--- a/src/edu/washington/escience/myria/daemon/MyriaDriverLauncher.java
+++ b/src/edu/washington/escience/myria/daemon/MyriaDriverLauncher.java
@@ -217,57 +217,64 @@ public final class MyriaDriverLauncher {
    * Used for logging command line arguments.
    */
   private static String genStartupMessage(Class<? extends Name<?>>[] classes, Injector inj) {
-    String allparams = Arrays.stream(classes).map(c -> {
-      final NamedParameter annotation = c.getAnnotation(NamedParameter.class);
+    String allparams =
+        Arrays.stream(classes)
+            .map(
+                c -> {
+                  final NamedParameter annotation = c.getAnnotation(NamedParameter.class);
 
-      final String fullName = c.getName();
-      final String simpleName = c.getSimpleName();
-      final String shortName = annotation.short_name();
-      final String doc = annotation.doc();
-      final String defaultVal;
-      {
-        if (!annotation.default_value().equals(NamedParameter.REEF_UNINITIALIZED_VALUE)) {
-          defaultVal = annotation.default_value();
-        } else if (!annotation.default_class().equals(Void.class)) {
-          defaultVal = annotation.default_class().getSimpleName();
-        } else if (annotation.default_values().length > 0) {
-          defaultVal = Arrays.toString(annotation.default_values());
-        } else if (annotation.default_classes().length > 0) {
-          final String classNames =
-              Arrays.stream(annotation.default_classes())
-                  .map(Class::getSimpleName)
-                  .reduce("", (a, b) -> a + ", " + b);
-          defaultVal = String.format("[%s]", classNames);
-        } else {
-          defaultVal = "";
-        }
-      }
+                  final String fullName = c.getName();
+                  final String simpleName = c.getSimpleName();
+                  final String shortName = annotation.short_name();
+                  final String doc = annotation.doc();
+                  final String defaultVal;
+                  {
+                    if (!annotation
+                        .default_value()
+                        .equals(NamedParameter.REEF_UNINITIALIZED_VALUE)) {
+                      defaultVal = annotation.default_value();
+                    } else if (!annotation.default_class().equals(Void.class)) {
+                      defaultVal = annotation.default_class().getSimpleName();
+                    } else if (annotation.default_values().length > 0) {
+                      defaultVal = Arrays.toString(annotation.default_values());
+                    } else if (annotation.default_classes().length > 0) {
+                      final String classNames =
+                          Arrays.stream(annotation.default_classes())
+                              .map(Class::getSimpleName)
+                              .reduce("", (a, b) -> a + ", " + b);
+                      defaultVal = String.format("[%s]", classNames);
+                    } else {
+                      defaultVal = "";
+                    }
+                  }
 
-      final StringBuilder sb = new StringBuilder(simpleName);
-      if (!shortName.isEmpty()) {
-        sb.append(" [-").append(shortName).append("]");
-      }
-      // If desired, the type of the parameter can be obtained from
-      // commandLineConf.getNamedParameters() --> .getSimpleArgName()
-      sb.append(": ").append(doc).append("\n -> ");
+                  final StringBuilder sb = new StringBuilder(simpleName);
+                  if (!shortName.isEmpty()) {
+                    sb.append(" [-").append(shortName).append("]");
+                  }
+                  // If desired, the type of the parameter can be obtained from
+                  // commandLineConf.getNamedParameters() --> .getSimpleArgName()
+                  sb.append(": ").append(doc).append("\n -> ");
 
-      boolean ok;
-      try {
-        ok = inj.isParameterSet(fullName);
-        if (ok) {
-          sb.append(inj.getInstance(fullName).toString());
-        }
-      } catch (InjectionException | BindException e) {
-        ok = false;
-      }
-      if (!ok) {
-        if (!defaultVal.isEmpty()) sb.append("[cannot parse; using default] ").append(defaultVal);
-        else sb.append("[cannot parse; no default]");
-      }
-      return sb.toString();
-    }).reduce("", (a, b) -> a + "\n" + b);
+                  boolean ok;
+                  try {
+                    ok = inj.isParameterSet(fullName);
+                    if (ok) {
+                      sb.append(inj.getInstance(fullName).toString());
+                    }
+                  } catch (InjectionException | BindException e) {
+                    ok = false;
+                  }
+                  if (!ok) {
+                    if (!defaultVal.isEmpty())
+                      sb.append("[cannot parse; using default] ").append(defaultVal);
+                    else sb.append("[cannot parse; no default]");
+                  }
+                  return sb.toString();
+                })
+            .reduce("", (a, b) -> a + "\n" + b);
 
-    return "MyriaDriverLauncher configuration:\n"+allparams;
+    return "MyriaDriverLauncher configuration:\n" + allparams;
   }
 
   /**


### PR DESCRIPTION
### Background

In order for the DriverLauncher to work, it must have a directory that is writeable by the DriverLauncher and readable by the launched Driver, on whatever node that Yarn allocates the Driver to.  The DriverLauncher places the myria jar and other configuration information inside this location, for transfer to the Driver itself.

The default file system this directory exists in is given by the fs.defaultFS parameter in core-site.xml.  If the defaultFS parameter is not specified, it defaults to file:///.  If you need to change the filesystem (say, to HDFS or to S3). then modify core-site.xml.

The default file location within the filesystem is /tmp.  If you need to change this, then specify the -driverDir parameter on the command line when you start Myria.

*** This will allow you to use Myria without HDFS. ***  (if you have a directory visible to both the driver launcher and the driver, wherever it is launched. For example, this is easy with a Lustre parallel file system.)


### CLI usage

The driver launcher will now log what parameters were expected along with their doc strings, and what parameters were given.