### PR TITLE
Implement streaming operator and API

### DIFF
--- a/src/edu/washington/escience/myria/api/DatasetResource.java
+++ b/src/edu/washington/escience/myria/api/DatasetResource.java
@@ -131,33 +131,6 @@ public final class DatasetResource {
   }
 
   /**
-   * Helper function to parse a format string, with default value "csv".
-   *
-   * @param format the format string, with default value "csv".
-   * @return the cleaned-up format string.
-   */
-  private String validateFormat(final String format) {
-    String cleanFormat = format;
-    if (cleanFormat == null) {
-      cleanFormat = "csv";
-    }
-    cleanFormat = cleanFormat.trim().toLowerCase();
-    /* CSV is legal */
-    if (cleanFormat.equals("csv")) {
-      return cleanFormat;
-    }
-    /* TSV is legal */
-    if (cleanFormat.equals("tsv")) {
-      return cleanFormat;
-    }
-    /* JSON is legal */
-    if (cleanFormat.equals("json")) {
-      return cleanFormat;
-    }
-    throw new MyriaApiException(Status.BAD_REQUEST, "format must be 'csv', 'tsv', or 'json'");
-  }
-
-  /**
    * @param userName the user who owns the target relation.
    * @param programName the program to which the target relation belongs.
    * @param relationName the name of the target relation.
@@ -184,7 +157,7 @@ public final class DatasetResource {
     RelationKey relationKey = RelationKey.of(userName, programName, relationName);
 
     /* Validate the request format. This will throw a MyriaApiException if format is invalid. */
-    String validFormat = validateFormat(format);
+    String validFormat = MyriaApiUtils.validateFormat(format);
 
     /*
      * Allocate the pipes by which the {@link DataOutput} operator will talk to the {@link StreamingOutput} object that
@@ -248,7 +221,7 @@ public final class DatasetResource {
     ResponseBuilder response = Response.ok();
 
     /* Validate the request format. This will throw a MyriaApiException if format is invalid. */
-    String validFormat = validateFormat(format);
+    String validFormat = MyriaApiUtils.validateFormat(format);
 
     /*
      * Allocate the pipes by which the {@link DataOutput} operator will talk to the {@link StreamingOutput} object that
@@ -328,7 +301,7 @@ public final class DatasetResource {
           Status.NOT_FOUND, "The dataset was not found: " + relationKey.toString());
     }
 
-    String validFormat = validateFormat(format);
+    String validFormat = MyriaApiUtils.validateFormat(format);
     Character delimiter;
     if (validFormat.equals("csv")) {
       delimiter = ',';

--- a/src/edu/washington/escience/myria/api/MyriaApiUtils.java
+++ b/src/edu/washington/escience/myria/api/MyriaApiUtils.java
@@ -2,6 +2,7 @@ package edu.washington.escience.myria.api;
 
 import javax.ws.rs.core.CacheControl;
 import javax.ws.rs.core.Response.ResponseBuilder;
+import javax.ws.rs.core.Response.Status;
 
 /**
  * Helper functions for the API.
@@ -29,5 +30,32 @@ public final class MyriaApiUtils {
    */
   public static ResponseBuilder doNotCache(final ResponseBuilder response) {
     return response.cacheControl(doNotCache());
+  }
+
+  /**
+   * Helper function to parse a format string, with default value "csv".
+   *
+   * @param format the format string, with default value "csv".
+   * @return the cleaned-up format string.
+   */
+  public static String validateFormat(final String format) {
+    String cleanFormat = format;
+    if (cleanFormat == null) {
+      cleanFormat = "csv";
+    }
+    cleanFormat = cleanFormat.trim().toLowerCase();
+    /* CSV is legal */
+    if (cleanFormat.equals("csv")) {
+      return cleanFormat;
+    }
+    /* TSV is legal */
+    if (cleanFormat.equals("tsv")) {
+      return cleanFormat;
+    }
+    /* JSON is legal */
+    if (cleanFormat.equals("json")) {
+      return cleanFormat;
+    }
+    throw new MyriaApiException(Status.BAD_REQUEST, "format must be 'csv', 'tsv', or 'json'");
   }
 }

--- a/src/edu/washington/escience/myria/api/encoding/OperatorEncoding.java
+++ b/src/edu/washington/escience/myria/api/encoding/OperatorEncoding.java
@@ -66,6 +66,7 @@ import edu.washington.escience.myria.operator.Operator;
   @Type(name = "SingleGroupByAggregate", value = SingleGroupByAggregateEncoding.class),
   @Type(name = "Singleton", value = SingletonEncoding.class),
   @Type(name = "StatefulApply", value = StatefulApplyEncoding.class),
+  @Type(name = "StreamingSink", value = StreamingSinkEncoding.class),
   @Type(name = "SymmetricHashJoin", value = SymmetricHashJoinEncoding.class),
   @Type(name = "SymmetricHashCountingJoin", value = SymmetricHashCountingJoinEncoding.class),
   @Type(name = "TableScan", value = TableScanEncoding.class),

--- a/src/edu/washington/escience/myria/api/encoding/QueryConstruct.java
+++ b/src/edu/washington/escience/myria/api/encoding/QueryConstruct.java
@@ -359,12 +359,12 @@ public class QueryConstruct {
    */
   private static void setAndVerifySingletonConstraints(
       final List<PlanFragmentEncoding> fragments, final ConstructArgs args) {
-    List<Integer> singletonWorkers =
-        ImmutableList.of(args.getServer().getAliveWorkers().iterator().next());
+    List<Integer> singletonWorkers = ImmutableList.of(MyriaConstants.MASTER_ID);
 
     for (PlanFragmentEncoding fragment : fragments) {
       for (OperatorEncoding<?> operator : fragment.operators) {
-        if (operator instanceof CollectConsumerEncoding
+        if (operator instanceof StreamingSinkEncoding
+            || operator instanceof CollectConsumerEncoding
             || operator instanceof SingletonEncoding
             || operator instanceof EOSControllerEncoding
             || operator instanceof TupleSourceEncoding

--- a/src/edu/washington/escience/myria/api/encoding/StreamingSinkEncoding.java
+++ b/src/edu/washington/escience/myria/api/encoding/StreamingSinkEncoding.java
@@ -1,0 +1,29 @@
+package edu.washington.escience.myria.api.encoding;
+
+import java.io.IOException;
+
+import javax.ws.rs.core.Response.Status;
+
+import edu.washington.escience.myria.CsvTupleWriter;
+import edu.washington.escience.myria.TupleWriter;
+import edu.washington.escience.myria.api.MyriaApiException;
+import edu.washington.escience.myria.api.encoding.QueryConstruct.ConstructArgs;
+import edu.washington.escience.myria.io.PipeSink;
+import edu.washington.escience.myria.operator.TupleSink;
+
+public class StreamingSinkEncoding extends UnaryOperatorEncoding<TupleSink> {
+
+  @Override
+  public TupleSink construct(final ConstructArgs args) throws MyriaApiException {
+    // TODO: dynamically select TupleWriter impl from API format parameter
+    final TupleWriter tupleWriter = new CsvTupleWriter();
+    final PipeSink dataSink;
+    try {
+      dataSink = new PipeSink();
+    } catch (IOException e) {
+      throw new MyriaApiException(Status.INTERNAL_SERVER_ERROR, e);
+    }
+    args.getServer().registerQueryOutput(args.getQueryId(), dataSink.getInputStream());
+    return new TupleSink(null, tupleWriter, dataSink);
+  }
+}

--- a/src/edu/washington/escience/myria/io/FileSink.java
+++ b/src/edu/washington/escience/myria/io/FileSink.java
@@ -6,6 +6,7 @@ import java.io.OutputStream;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import edu.washington.escience.myria.coordinator.CatalogException;
@@ -14,8 +15,9 @@ public class FileSink implements DataSink {
   /** Required for Java serialization. */
   private static final long serialVersionUID = 1L;
 
-  @JsonProperty private String filename;
+  private String filename;
 
+  @JsonCreator
   public FileSink(@JsonProperty(value = "filename", required = true) final String filename)
       throws CatalogException {
     this.filename = filename;

--- a/src/edu/washington/escience/myria/io/PipeSink.java
+++ b/src/edu/washington/escience/myria/io/PipeSink.java
@@ -1,27 +1,25 @@
-/**
- *
- */
 package edu.washington.escience.myria.io;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 import edu.washington.escience.myria.MyriaConstants;
 import edu.washington.escience.myria.api.PipedStreamingOutput;
 
-/**
- *
- */
 public class PipeSink implements DataSink {
   /** Required for Java serialization. */
   private static final long serialVersionUID = 1L;
 
-  final PipedOutputStream writerOutput;
-  final PipedInputStream input;
-  final PipedStreamingOutput responseEntity;
+  private final PipedOutputStream writerOutput;
+  private final PipedInputStream input;
+  private final PipedStreamingOutput responseEntity;
 
+  @JsonCreator
   public PipeSink() throws IOException {
     writerOutput = new PipedOutputStream();
     input = new PipedInputStream(writerOutput, MyriaConstants.DEFAULT_PIPED_INPUT_STREAM_SIZE);
@@ -35,5 +33,9 @@ public class PipeSink implements DataSink {
 
   public PipedStreamingOutput getResponse() {
     return responseEntity;
+  }
+
+  public InputStream getInputStream() {
+    return input;
   }
 }

--- a/src/edu/washington/escience/myria/parallel/Query.java
+++ b/src/edu/washington/escience/myria/parallel/Query.java
@@ -1,10 +1,13 @@
 package edu.washington.escience.myria.parallel;
 
+import java.io.InputStream;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import javax.annotation.Nonnull;
 import javax.annotation.concurrent.GuardedBy;
@@ -15,6 +18,7 @@ import org.slf4j.LoggerFactory;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Verify;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
 import edu.washington.escience.myria.DbException;
@@ -77,6 +81,8 @@ public final class Query {
   private final ConcurrentHashMap<RelationKey, RelationWriteMetadata> tempRelations;
   /** resource usage stats of workers. */
   private final ConcurrentHashMap<Integer, ConcurrentLinkedDeque<ResourceStats>> resourceUsage;
+  /** Registered outputs of this query (InputStreams because they will be read by clients). */
+  private final List<InputStream> registeredOutputs;
 
   /**
    * Construct a new {@link Query} object for this query.
@@ -106,6 +112,7 @@ public final class Query {
     globals = new ConcurrentHashMap<>();
     tempRelations = new ConcurrentHashMap<>();
     resourceUsage = new ConcurrentHashMap<Integer, ConcurrentLinkedDeque<ResourceStats>>();
+    registeredOutputs = new CopyOnWriteArrayList<>();
   }
 
   /**
@@ -359,6 +366,22 @@ public final class Query {
    */
   public Object getGlobal(final String key) {
     return globals.get(key);
+  }
+
+  /**
+   * Register an output of this query ({@link InputStream} because it must be read by callers).
+   *
+   * @param output the InputStream corresponding to an output of this query
+   */
+  public void registerOutput(final InputStream output) {
+    registeredOutputs.add(output);
+  }
+
+  /**
+   * Return all registered outputs of this query, in order of registration.
+   */
+  public ImmutableList<InputStream> getRegisteredOutputs() {
+    return ImmutableList.copyOf(registeredOutputs);
   }
 
   /**

--- a/src/edu/washington/escience/myria/parallel/QueryManager.java
+++ b/src/edu/washington/escience/myria/parallel/QueryManager.java
@@ -458,7 +458,7 @@ public class QueryManager {
             .getIPCConnectionPool()
             .sendShortMessage(workerId, IPCUtils.queryMessage(mqp.getSubQueryId(), e.getValue()));
       } catch (final IOException ee) {
-        throw new DbException(ee);
+        throw new DbException("Worker ID: " + workerId, ee);
       }
     }
     return mqp.getWorkerReceiveFuture();

--- a/src/edu/washington/escience/myria/parallel/Server.java
+++ b/src/edu/washington/escience/myria/parallel/Server.java
@@ -3,7 +3,9 @@ package edu.washington.escience.myria.parallel;
 import java.io.ByteArrayInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.ObjectInputStream;
+import java.io.SequenceInputStream;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -2278,6 +2280,30 @@ public final class Server implements TaskMessageSource, EventHandler<DriverMessa
   public Object getQueryGlobal(final long queryId, @Nonnull final String key) {
     Preconditions.checkNotNull(key, "key");
     return queryManager.getQuery(queryId).getGlobal(key);
+  }
+
+  /**
+   * Registers the {@link InputStream} corresponding to an output of the specified query.
+   * NB: The output is an {@link InputStream} rather than an {@link OutputStream} because callers want to read it.
+   *
+   * @param queryId the query producing this output
+   * @param queryOutput the {@link InputStream} corresponding to this output
+   */
+  public void registerQueryOutput(final long queryId, @Nonnull final InputStream queryOutput) {
+    Preconditions.checkNotNull(queryOutput, "queryOutput");
+    queryManager.getQuery(queryId).registerOutput(queryOutput);
+  }
+
+  /**
+   * Returns an {@link InputStream} containing all registered outputs of the specified query,
+   * in order of registration.
+   * NB: The output is an {@link InputStream} rather than an {@link OutputStream} because callers want to read it.
+   *
+   * @param queryId the query producing this output
+   */
+  public InputStream getQueryOutput(final long queryId) {
+    return new SequenceInputStream(
+        Collections.enumeration(queryManager.getQuery(queryId).getRegisteredOutputs()));
   }
 
   /**


### PR DESCRIPTION
This first draft doesn't even work properly for all but the simplest examples, but I wanted to get feedback on the design sooner rather than later. Briefly, I'm introducing a new MyriaL statement `stream(relationVar)` analogous to `store()` and `sink()`. Whenever a `stream()` statement appears, RACO inserts a `Stream` pseudo-operator which is expanded into a chain of MyriaX operators `CollectProducer->CollectConsumer->StreamingSink` (the latter is a pseudo-operator defined in MyriaX). On the MyriaX side, `StreamingSink` is expanded from its encoding to a `TupleSink` with a `PipeSink` instance of its `DataSink` member, so we can get an `InputStream` with the query results. In `StreamingSink.construct()`, the `PipeSink`'s `InputStream` is registered with the `QueryManager` under its query ID so we can retrieve it later and connect it to the HTTP `Response` object. In `QueryResource.postNewStreamingQuery()`, which is mapped to the new `/query/stream` endpoint, we retrieve all registered `InputStream`s from `PipeSink`s instantiated as part of a `StreamingSink` in the query plan, and form a `SequenceInputStream` which we pass to `ResponseBuilder.entity()`, so the HTTP client receives all outputs in the order in which their respective `stream()` statements appeared in the MyriaL query.

This does seem to work for simple queries like this:
```
E = scan(TwitterK);
V = select distinct E.$0 from E;
stream(V);
```

But it fails with the connected components sample query from myria-web, and also with sequenced `stream()` statements like this:
```
T1 = load("file://Users/tdbaker/sequence_test_1.txt",
csv(schema(col1:string),skip=0));
stream(T1);
T2 = load("file://Users/tdbaker/sequence_test_2.txt",
csv(schema(col1:string),skip=0));
stream(T2);
T3 = load("file://Users/tdbaker/sequence_test_3.txt",
csv(schema(col1:string),skip=0));
stream(T3);
```

I haven't diagnosed the CC query failure yet, but I think the sequence query failure is due to a simple deadlock. I think the Myria `Sequence` operator has to wait for each subquery to finish before running the next one, but that requires the client to consume all tuples, and somehow the `SequenceInputStream` that combines subquery results isn't flushed until the entire query has finished.

