### PR TITLE
track source relations in QueryScanEncoding

### DIFF
--- a/src/edu/washington/escience/myria/api/encoding/QueryScanEncoding.java
+++ b/src/edu/washington/escience/myria/api/encoding/QueryScanEncoding.java
@@ -1,5 +1,8 @@
 package edu.washington.escience.myria.api.encoding;
 
+import java.util.List;
+
+import edu.washington.escience.myria.RelationKey;
 import edu.washington.escience.myria.Schema;
 import edu.washington.escience.myria.api.encoding.QueryConstruct.ConstructArgs;
 import edu.washington.escience.myria.operator.DbQueryScan;
@@ -7,6 +10,7 @@ import edu.washington.escience.myria.operator.DbQueryScan;
 public class QueryScanEncoding extends LeafOperatorEncoding<DbQueryScan> {
   @Required public Schema schema;
   @Required public String sql;
+  @Required public List<RelationKey> sourceRelationKeys;
 
   @Override
   public DbQueryScan construct(ConstructArgs args) {


### PR DESCRIPTION
fixes #758

This is a prerequisite for pushing debroadcast into MyriaX as @jingjingwang and I discussed after the 1/3/2016 Myria meeting.

This must be deployed in parallel with https://github.com/uwescience/raco/pull/546.