### PR TITLE
fix_constant_emit_in_statefulapply

### DIFF
--- a/src/edu/washington/escience/myria/api/DatasetResource.java
+++ b/src/edu/washington/escience/myria/api/DatasetResource.java
@@ -103,11 +103,11 @@ public final class DatasetResource {
       @PathParam("programName") final String programName,
       @PathParam("relationName") final String relationName)
       throws DbException {
-    DatasetStatus status =
-        server.getDatasetStatus(RelationKey.of(userName, programName, relationName));
+    RelationKey relationKey = RelationKey.of(userName, programName, relationName);
+    DatasetStatus status = server.getDatasetStatus(relationKey);
     if (status == null) {
       /* Not found, throw a 404 (Not Found) */
-      throw new MyriaApiException(Status.NOT_FOUND, "That dataset was not found");
+      throw new MyriaApiException(Status.NOT_FOUND, "Dataset " + relationKey + " was not found");
     }
     status.setUri(getCanonicalResourcePath(uriInfo, status.getRelationKey()));
     /* Yay, worked! */
@@ -355,13 +355,12 @@ public final class DatasetResource {
       @PathParam("programName") final String programName,
       @PathParam("relationName") final String relationName)
       throws DbException {
-    DatasetStatus status =
-        server.getDatasetStatus(RelationKey.of(userName, programName, relationName));
+    RelationKey relationKey = RelationKey.of(userName, programName, relationName);
+    DatasetStatus status = server.getDatasetStatus(relationKey);
     if (status == null) {
       /* Dataset not found, throw a 404 (Not Found) */
-      throw new MyriaApiException(Status.NOT_FOUND, "That dataset was not found");
+      throw new MyriaApiException(Status.NOT_FOUND, "Dataset " + relationKey + " was not found");
     }
-    RelationKey relationKey = status.getRelationKey();
     // delete command
     try {
       server.deleteDataset(relationKey);
@@ -586,7 +585,7 @@ public final class DatasetResource {
     /* Check overwriting existing dataset. */
     try {
       if (!MoreObjects.firstNonNull(overwrite, false) && server.getSchema(relationKey) != null) {
-        throw new MyriaApiException(Status.CONFLICT, "That dataset already exists.");
+        throw new MyriaApiException(Status.CONFLICT, "Dataset " + relationKey + " already exists.");
       }
     } catch (CatalogException e) {
       throw new DbException(e);
@@ -662,7 +661,8 @@ public final class DatasetResource {
       if (!MoreObjects.firstNonNull(dataset.overwrite, Boolean.FALSE)
           && server.getSchema(dataset.relationKey) != null) {
         /* Found, throw a 409 (Conflict) */
-        throw new MyriaApiException(Status.CONFLICT, "That dataset already exists.");
+        throw new MyriaApiException(
+            Status.CONFLICT, "Dataset " + dataset.relationKey + " already exists.");
       }
     } catch (CatalogException e) {
       throw new DbException(e);

--- a/src/edu/washington/escience/myria/operator/StatefulApply.java
+++ b/src/edu/washington/escience/myria/operator/StatefulApply.java
@@ -166,9 +166,15 @@ public class StatefulApply extends Apply {
     ArrayList<GenericEvaluator> evaluators = new ArrayList<>();
     evaluators.ensureCapacity(getEmitExpressions().size());
     for (Expression expr : getEmitExpressions()) {
-      GenericEvaluator evaluator =
-          new GenericEvaluator(
-              expr, new ExpressionOperatorParameter(inputSchema, getStateSchema(), getNodeID()));
+      GenericEvaluator evaluator;
+      if (expr.isConstant()) {
+        evaluator =
+            new ConstantEvaluator(expr, new ExpressionOperatorParameter(inputSchema, getNodeID()));
+      } else {
+        evaluator =
+            new GenericEvaluator(
+                expr, new ExpressionOperatorParameter(inputSchema, getStateSchema(), getNodeID()));
+      }
       if (evaluator.needsCompiling()) {
         evaluator.compile();
       }


### PR DESCRIPTION
If a `StatefulApply` has a constant emitter (e.g. sin(-1)), it still constructs a `GenericEvaluator` for it, which is not compiled (due to being a constant). Then the evaluator is null when `eval()` is called. Instead, a `ConstantEvaluator` should be constructed (same as in `Apply`), which compiles in its constructor. A counter example is:

`APPLY counter() {
  [0 AS c];
  [c + 1];
  c;
};
R = scan(TwitterK);
R_seq = select R.*, sin(-1) as t, counter() as c from R;`