### PR TITLE
cp -n return non-zero code when deployment.cfg exists

### DIFF
--- a/myriadeploy/launch_local_cluster
+++ b/myriadeploy/launch_local_cluster
@@ -1,5 +1,8 @@
 #!/bin/bash
 set -e
 REPO_ROOT=$(git rev-parse --show-toplevel)
-cp -n "$REPO_ROOT/myriadeploy/deployment.cfg.local" "$REPO_ROOT/myriadeploy/deployment.cfg"
+if [ ! -f "$REPO_ROOT/myriadeploy/deployment.cfg" ]
+then
+    cp "$REPO_ROOT/myriadeploy/deployment.cfg.local" "$REPO_ROOT/myriadeploy/deployment.cfg"
+fi
 "$JAVA_HOME/bin/java" -cp "$REPO_ROOT/build/libs/myria-0.1-all.jar" edu.washington.escience.myria.daemon.MyriaDriverLauncher -runtimeClass org.apache.reef.runtime.local.client.LocalRuntimeConfiguration -configPath "$REPO_ROOT/myriadeploy" -javaLibPath "$REPO_ROOT/build/libs" -nativeLibPath "$REPO_ROOT/lib"


### PR DESCRIPTION
After setting `set -e` in #886, `cp -n` would cause the script to exit if `deployment.cfg` were already there. According to https://www.freebsd.org/cgi/man.cgi?cp, `-n` is non-standard so use an `if` to detect that.