### PR TITLE
fixing parallel ingest single worker case

### DIFF
--- a/src/edu/washington/escience/myria/operator/CSVFragmentTupleSource.java
+++ b/src/edu/washington/escience/myria/operator/CSVFragmentTupleSource.java
@@ -416,7 +416,7 @@ public class CSVFragmentTupleSource extends LeafOperator {
         }
       }
       if (workerIndex >= 0) {
-        boolean isLastWorker = workerIndex == workerIds.length - 1;
+        boolean isLastWorker = (workerIndex == workerIds.length - 1);
         long startByteRange = currentPartitionSize * workerIndex;
         long endByteRange;
 

--- a/src/edu/washington/escience/myria/operator/CSVFragmentTupleSource.java
+++ b/src/edu/washington/escience/myria/operator/CSVFragmentTupleSource.java
@@ -409,24 +409,28 @@ public class CSVFragmentTupleSource extends LeafOperator {
       int workerID = getNodeID();
       long fileSize = source.getFileSize();
       long currentPartitionSize = fileSize / workerIds.length;
-      int workerIndex = 0;
+      int workerIndex = -1;
       for (int i = 0; i < workerIds.length; i++) {
         if (workerID == workerIds[i]) {
           workerIndex = i;
         }
       }
-      boolean isLastWorker = workerIndex == workerIds.length - 1;
-      long startByteRange = currentPartitionSize * workerIndex;
-      long endByteRange;
+      if (workerIndex >= 0) {
+        boolean isLastWorker = workerIndex == workerIds.length - 1;
+        long startByteRange = currentPartitionSize * workerIndex;
+        long endByteRange;
 
-      if (isLastWorker) {
-        endByteRange = fileSize - 1;
+        if (isLastWorker) {
+          endByteRange = fileSize - 1;
+        } else {
+          endByteRange = (currentPartitionSize * (workerIndex + 1)) - 1;
+        }
+        this.partitionStartByteRange = startByteRange;
+        this.partitionEndByteRange = endByteRange;
+        this.isLastWorker = isLastWorker;
       } else {
-        endByteRange = (currentPartitionSize * (workerIndex + 1)) - 1;
+        flagAsIncomplete = true;
       }
-      this.partitionStartByteRange = startByteRange;
-      this.partitionEndByteRange = endByteRange;
-      this.isLastWorker = isLastWorker;
     }
 
     try {


### PR DESCRIPTION
Fixing an ingest bug for cases where parallel ingest only needed a single worker to read a file. With the old code, every worker would try to read the entire file (since `workerIndex` value was kept at 0). In other words, every worker would believe they were the first worker. 

Now, `workerIndex` starts at -1 and is only assigned to read the file if it is found in the workerIds array. If `workerIndex` is kept at -1, we mark `flagAsIncomplete` as True which then makes sure to not initialize the parser for the current worker. 
