### PR TITLE
specify a size to a column builder

### DIFF
--- a/src/edu/washington/escience/myria/MyriaConstants.java
+++ b/src/edu/washington/escience/myria/MyriaConstants.java
@@ -12,24 +12,16 @@ public final class MyriaConstants {
    */
   public static final String SYSTEM_NAME = "Myria";
 
-  /**
-   * 1 kb.
-   */
+  /** 1 KB. */
   public static final int KB = 1024;
 
-  /**
-   * 1 mb.
-   */
+  /** 1 MB. */
   public static final int MB = 1024 * KB;
 
-  /**
-   * 1 gb.
-   */
+  /** 1 GB. */
   public static final int GB = 1024 * MB;
 
-  /**
-   * 1 tb.
-   */
+  /** 1 TB. */
   public static final int TB = 1024 * GB;
 
   /**
@@ -203,12 +195,15 @@ public final class MyriaConstants {
    * The number of bytes that can back up in a {@link java.io.PipedInputStream} before we stop writing tuples and wait
    * for the client to read them. 16 MB.
    */
-  public static final int DEFAULT_PIPED_INPUT_STREAM_SIZE = 1024 * 1024 * 16;
+  public static final int DEFAULT_PIPED_INPUT_STREAM_SIZE = 16 * MB;
 
   /**
    * The maximum number of currently active (running, queued, paused, ...) queries at the master.
    */
   public static final int MAX_ACTIVE_QUERIES = 25;
+
+  /** Default size of a TupleBatch. */
+  public static final int TUPLE_BATCH_DEFAULT_SIZE = 10 * 1000;
 
   /**
    * The relation that stores profiling information about which operators executed when.

--- a/src/edu/washington/escience/myria/column/builder/BlobColumnBuilder.java
+++ b/src/edu/washington/escience/myria/column/builder/BlobColumnBuilder.java
@@ -37,10 +37,12 @@ public final class BlobColumnBuilder extends ColumnBuilder<ByteBuffer> {
    */
   private boolean built = false;
 
-  /** Constructs an empty column that can hold up to TupleBatch.BATCH_SIZE elements. */
-  public BlobColumnBuilder() {
+  /** Constructs an empty column with the given capacity.
+   * @param size the capacity.
+   * */
+  public BlobColumnBuilder(final int size) {
     numBB = 0;
-    data = new ByteBuffer[TupleUtils.getBatchSize(Type.BLOB_TYPE)];
+    data = new ByteBuffer[size];
   }
 
   /**

--- a/src/edu/washington/escience/myria/column/builder/BooleanColumnBuilder.java
+++ b/src/edu/washington/escience/myria/column/builder/BooleanColumnBuilder.java
@@ -3,19 +3,16 @@ package edu.washington.escience.myria.column.builder;
 import java.nio.BufferOverflowException;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Arrays;
 import java.util.BitSet;
 
 import com.almworks.sqlite4java.SQLiteException;
 import com.almworks.sqlite4java.SQLiteStatement;
 import com.google.common.base.Preconditions;
 
-import edu.washington.escience.myria.Schema;
 import edu.washington.escience.myria.Type;
 import edu.washington.escience.myria.column.BooleanColumn;
 import edu.washington.escience.myria.column.mutable.BooleanMutableColumn;
 import edu.washington.escience.myria.proto.DataProto.ColumnMessage;
-import edu.washington.escience.myria.storage.TupleBatch;
 import edu.washington.escience.myria.storage.TupleUtils;
 import edu.washington.escience.myria.util.MyriaUtils;
 
@@ -38,12 +35,13 @@ public final class BooleanColumnBuilder extends ColumnBuilder<Boolean> {
    * */
   private boolean built = false;
 
-  /** Constructs an empty column that can hold up to TupleBatch.BATCH_SIZE elements. */
-  public BooleanColumnBuilder() {
+  /** Constructs an empty column that can hold up to size elements.
+   * @param size the size of the column.
+   * */
+  public BooleanColumnBuilder(final int size) {
     data = new BitSet();
     numBits = 0;
-    int batchSize = TupleUtils.getBatchSize(Type.BOOLEAN_TYPE);
-    capacity = batchSize;
+    capacity = size;
   }
 
   /**

--- a/src/edu/washington/escience/myria/column/builder/ColumnBuilder.java
+++ b/src/edu/washington/escience/myria/column/builder/ColumnBuilder.java
@@ -8,11 +8,10 @@ import java.sql.SQLException;
 import javax.annotation.Nonnull;
 
 import org.joda.time.DateTime;
-import java.nio.ByteBuffer;
+
 import com.almworks.sqlite4java.SQLiteException;
 import com.almworks.sqlite4java.SQLiteStatement;
 
-import edu.washington.escience.myria.Type;
 import edu.washington.escience.myria.column.Column;
 import edu.washington.escience.myria.column.mutable.MutableColumn;
 import edu.washington.escience.myria.storage.ReadableColumn;
@@ -198,6 +197,7 @@ public abstract class ColumnBuilder<T extends Comparable<?>>
    * @param type the type of the column to be returned.
    * @return a new empty column of the specified type.
    */
+  /*
   public static ColumnBuilder<?> of(final Type type) {
     switch (type) {
       case BOOLEAN_TYPE:
@@ -218,6 +218,7 @@ public abstract class ColumnBuilder<T extends Comparable<?>>
         throw new IllegalArgumentException("Type " + type + " is invalid");
     }
   }
+  */
 
   @Override
   public void replaceBlob(@Nonnull final ByteBuffer value, final int row) {

--- a/src/edu/washington/escience/myria/column/builder/ColumnFactory.java
+++ b/src/edu/washington/escience/myria/column/builder/ColumnFactory.java
@@ -7,6 +7,7 @@ import edu.washington.escience.myria.Schema;
 import edu.washington.escience.myria.Type;
 import edu.washington.escience.myria.column.Column;
 import edu.washington.escience.myria.proto.DataProto.ColumnMessage;
+import edu.washington.escience.myria.storage.TupleUtils;
 
 /**
  * A column of a batch of tuples.
@@ -19,26 +20,27 @@ public final class ColumnFactory {
    * Allocate a ColumnBuilder for the specified Myria type.
    *
    * @param type the Myria type of the returned Builder.
+   * @param size the size of the column.
    * @return a ColumnBuilder for the specified Myria type.
    */
-  public static ColumnBuilder<?> allocateColumn(final Type type) {
+  public static ColumnBuilder<?> allocateColumn(final Type type, final int size) {
     switch (type) {
       case BOOLEAN_TYPE:
-        return new BooleanColumnBuilder();
+        return new BooleanColumnBuilder(size);
       case DOUBLE_TYPE:
-        return new DoubleColumnBuilder();
+        return new DoubleColumnBuilder(size);
       case FLOAT_TYPE:
-        return new FloatColumnBuilder();
+        return new FloatColumnBuilder(size);
       case INT_TYPE:
-        return new IntColumnBuilder();
+        return new IntColumnBuilder(size);
       case LONG_TYPE:
-        return new LongColumnBuilder();
+        return new LongColumnBuilder(size);
       case STRING_TYPE:
-        return new StringColumnBuilder();
+        return new StringColumnBuilder(size);
       case DATETIME_TYPE:
-        return new DateTimeColumnBuilder();
+        return new DateTimeColumnBuilder(size);
       case BLOB_TYPE:
-        return new BlobColumnBuilder();
+        return new BlobColumnBuilder(size);
     }
     throw new IllegalArgumentException("Cannot allocate a ColumnBuilder for unknown type " + type);
   }
@@ -60,9 +62,10 @@ public final class ColumnFactory {
    * @return the allocated Columns
    */
   public static List<ColumnBuilder<?>> allocateColumns(final List<Type> columnTypes) {
+    final int size = TupleUtils.getBatchSize(columnTypes);
     final ArrayList<ColumnBuilder<?>> columns = new ArrayList<ColumnBuilder<?>>(columnTypes.size());
     for (Type type : columnTypes) {
-      columns.add(allocateColumn(type));
+      columns.add(allocateColumn(type, size));
     }
     return columns;
   }

--- a/src/edu/washington/escience/myria/column/builder/DateTimeColumnBuilder.java
+++ b/src/edu/washington/escience/myria/column/builder/DateTimeColumnBuilder.java
@@ -17,7 +17,6 @@ import edu.washington.escience.myria.column.DateTimeColumn;
 import edu.washington.escience.myria.column.mutable.DateTimeMutableColumn;
 import edu.washington.escience.myria.proto.DataProto.ColumnMessage;
 import edu.washington.escience.myria.proto.DataProto.DateTimeColumnMessage;
-import edu.washington.escience.myria.storage.TupleBatch;
 import edu.washington.escience.myria.storage.TupleUtils;
 import edu.washington.escience.myria.util.MyriaUtils;
 
@@ -41,9 +40,9 @@ public final class DateTimeColumnBuilder extends ColumnBuilder<DateTime> {
   private boolean built = false;
 
   /** Constructs an empty column that can hold up to TupleBatch.BATCH_SIZE elements. */
-  public DateTimeColumnBuilder() {
+  public DateTimeColumnBuilder(final int size) {
     numDates = 0;
-    data = new DateTime[TupleUtils.getBatchSize(Type.DATETIME_TYPE)];
+    data = new DateTime[size];
   }
 
   /**

--- a/src/edu/washington/escience/myria/column/builder/DoubleColumnBuilder.java
+++ b/src/edu/washington/escience/myria/column/builder/DoubleColumnBuilder.java
@@ -14,8 +14,6 @@ import edu.washington.escience.myria.Type;
 import edu.washington.escience.myria.column.DoubleColumn;
 import edu.washington.escience.myria.column.mutable.DoubleMutableColumn;
 import edu.washington.escience.myria.proto.DataProto.ColumnMessage;
-import edu.washington.escience.myria.storage.TupleBatch;
-import edu.washington.escience.myria.storage.TupleUtils;
 import edu.washington.escience.myria.util.MyriaUtils;
 
 /**
@@ -31,9 +29,11 @@ public final class DoubleColumnBuilder extends ColumnBuilder<Double> {
    * */
   private boolean built = false;
 
-  /** Constructs an empty column that can hold up to TupleBatch.BATCH_SIZE elements. */
-  public DoubleColumnBuilder() {
-    data = DoubleBuffer.allocate(TupleUtils.getBatchSize(Type.DOUBLE_TYPE));
+  /** Constructs an empty column with the given capacity.
+   * @param size the capacity.
+   * */
+  public DoubleColumnBuilder(final int size) {
+    data = DoubleBuffer.allocate(size);
   }
 
   /**

--- a/src/edu/washington/escience/myria/column/builder/FloatColumnBuilder.java
+++ b/src/edu/washington/escience/myria/column/builder/FloatColumnBuilder.java
@@ -14,8 +14,6 @@ import edu.washington.escience.myria.Type;
 import edu.washington.escience.myria.column.FloatColumn;
 import edu.washington.escience.myria.column.mutable.FloatMutableColumn;
 import edu.washington.escience.myria.proto.DataProto.ColumnMessage;
-import edu.washington.escience.myria.storage.TupleBatch;
-import edu.washington.escience.myria.storage.TupleUtils;
 import edu.washington.escience.myria.util.MyriaUtils;
 
 /**
@@ -31,9 +29,11 @@ public final class FloatColumnBuilder extends ColumnBuilder<Float> {
    * */
   private boolean built = false;
 
-  /** Constructs an empty column that can hold up to TupleBatch.BATCH_SIZE elements. */
-  public FloatColumnBuilder() {
-    data = FloatBuffer.allocate(TupleUtils.getBatchSize(Type.FLOAT_TYPE));
+  /** Constructs an empty column with the given capacity.
+   * @param size the capacity.
+   * */
+  public FloatColumnBuilder(final int size) {
+    data = FloatBuffer.allocate(size);
   }
 
   /**

--- a/src/edu/washington/escience/myria/column/builder/IntColumnBuilder.java
+++ b/src/edu/washington/escience/myria/column/builder/IntColumnBuilder.java
@@ -15,8 +15,6 @@ import edu.washington.escience.myria.column.IntColumn;
 import edu.washington.escience.myria.column.IntProtoColumn;
 import edu.washington.escience.myria.column.mutable.IntMutableColumn;
 import edu.washington.escience.myria.proto.DataProto.ColumnMessage;
-import edu.washington.escience.myria.storage.TupleBatch;
-import edu.washington.escience.myria.storage.TupleUtils;
 import edu.washington.escience.myria.util.MyriaUtils;
 
 /**
@@ -32,9 +30,11 @@ public final class IntColumnBuilder extends ColumnBuilder<Integer> {
    * */
   private boolean built = false;
 
-  /** Constructs an empty column that can hold up to TupleBatch.BATCH_SIZE elements. */
-  public IntColumnBuilder() {
-    data = IntBuffer.allocate(TupleUtils.getBatchSize(Type.INT_TYPE));
+  /** Constructs an empty column with the given capacity.
+   * @param size the capacity.
+   * */
+  public IntColumnBuilder(final int size) {
+    data = IntBuffer.allocate(size);
   }
 
   /**

--- a/src/edu/washington/escience/myria/column/builder/LongColumnBuilder.java
+++ b/src/edu/washington/escience/myria/column/builder/LongColumnBuilder.java
@@ -14,8 +14,6 @@ import edu.washington.escience.myria.Type;
 import edu.washington.escience.myria.column.LongColumn;
 import edu.washington.escience.myria.column.mutable.LongMutableColumn;
 import edu.washington.escience.myria.proto.DataProto.ColumnMessage;
-import edu.washington.escience.myria.storage.TupleBatch;
-import edu.washington.escience.myria.storage.TupleUtils;
 import edu.washington.escience.myria.util.MyriaUtils;
 
 /**
@@ -31,9 +29,11 @@ public final class LongColumnBuilder extends ColumnBuilder<Long> {
    * */
   private boolean built = false;
 
-  /** Constructs an empty column that can hold up to TupleBatch.BATCH_SIZE elements. */
-  public LongColumnBuilder() {
-    data = LongBuffer.allocate(TupleUtils.getBatchSize(Type.LONG_TYPE));
+  /** Constructs an empty column with the given capacity.
+   * @param size the capacity.
+   * */
+  public LongColumnBuilder(final int size) {
+    data = LongBuffer.allocate(size);
   }
 
   /**

--- a/src/edu/washington/escience/myria/column/builder/StringColumnBuilder.java
+++ b/src/edu/washington/escience/myria/column/builder/StringColumnBuilder.java
@@ -36,10 +36,12 @@ public final class StringColumnBuilder extends ColumnBuilder<String> {
    */
   private boolean built = false;
 
-  /** Constructs an empty column that can hold up to TupleBatch.BATCH_SIZE elements. */
-  public StringColumnBuilder() {
+  /** Constructs an empty column with the given capacity.
+   * @param size the capacity.
+   * */
+  public StringColumnBuilder(final int size) {
     numStrings = 0;
-    data = new String[TupleUtils.getBatchSize(Type.STRING_TYPE)];
+    data = new String[size];
   }
 
   /**

--- a/src/edu/washington/escience/myria/expression/evaluate/GenericEvaluator.java
+++ b/src/edu/washington/escience/myria/expression/evaluate/GenericEvaluator.java
@@ -260,7 +260,7 @@ public class GenericEvaluator extends Evaluator {
     // For single-valued expressions, the Java expression will never attempt to write to `countsWriter`.
     WritableColumn countsWriter = null;
     if (getExpression().isMultiValued()) {
-      countsWriter = ColumnFactory.allocateColumn(Type.INT_TYPE);
+      countsWriter = ColumnFactory.allocateColumn(Type.INT_TYPE, batchSize);
     }
     for (int rowIdx = 0; rowIdx < tb.numTuples(); ++rowIdx) {
       /* Hack, tb is either Expression.INPUT or Expression.STATE */

--- a/src/edu/washington/escience/myria/expression/evaluate/PythonUDFEvaluator.java
+++ b/src/edu/washington/escience/myria/expression/evaluate/PythonUDFEvaluator.java
@@ -7,11 +7,11 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.nio.charset.StandardCharsets;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -188,16 +188,14 @@ public class PythonUDFEvaluator extends GenericEvaluator {
           writeToStream(buffer, row, i);
         }
       }
-      ColumnBuilder<?> output = ColumnFactory.allocateColumn(outputType);
+      ColumnBuilder<?> output = ColumnFactory.allocateColumn(outputType, 1);
       /* TODO: Leaving the count column to be null for now since since it's not used by Python evaluator for aggregate.
        * A better design is to let the Aggregator emit two columns or even multiple columns. */
       readFromStream(null, output);
       if (output.size() > 1) {
         throw new RuntimeException("PythonUDFEvaluator cannot be multivalued for Aggregate");
       }
-      for (int i = 0; i < output.size(); ++i) {
-        state.replace(col, key, output, i);
-      }
+      state.replace(col, key, output, 0);
     }
   }
 

--- a/src/edu/washington/escience/myria/operator/Counter.java
+++ b/src/edu/washington/escience/myria/operator/Counter.java
@@ -52,7 +52,7 @@ public class Counter extends UnaryOperator {
     if (childTuples == null) {
       return null;
     }
-    LongColumnBuilder builder = new LongColumnBuilder();
+    LongColumnBuilder builder = new LongColumnBuilder(childTuples.numTuples());
     for (int i = 0; i < childTuples.numTuples(); ++i) {
       builder.appendLong(count);
       ++count;

--- a/src/edu/washington/escience/myria/operator/StatefulApply.java
+++ b/src/edu/washington/escience/myria/operator/StatefulApply.java
@@ -129,18 +129,16 @@ public class StatefulApply extends Apply {
     }
 
     // second, build and add the columns that require state
-    List<ColumnBuilder<?>> columnBuilders = Lists.newArrayListWithCapacity(needState.size());
+    List<Type> outputTypes = new ArrayList<Type>();
     for (int builderIdx = 0; builderIdx < needState.size(); builderIdx++) {
-      columnBuilders.add(
-          ColumnFactory.allocateColumn(
-              getEmitEvaluators().get(needState.get(builderIdx)).getOutputType()));
+      outputTypes.add(getEmitEvaluators().get(needState.get(builderIdx)).getOutputType());
     }
+    List<ColumnBuilder<?>> columnBuilders = ColumnFactory.allocateColumns(outputTypes);
 
     for (int rowIdx = 0; rowIdx < tb.numTuples(); rowIdx++) {
       // update state
       Tuple newState = new Tuple(getStateSchema());
       for (int columnIdx = 0; columnIdx < stateSchema.numColumns(); columnIdx++) {
-
         updateEvaluators
             .get(columnIdx)
             .eval(tb, rowIdx, state, 0, newState.asWritableColumn(columnIdx), null);

--- a/src/edu/washington/escience/myria/storage/TupleUtils.java
+++ b/src/edu/washington/escience/myria/storage/TupleUtils.java
@@ -1,7 +1,10 @@
 package edu.washington.escience.myria.storage;
 
+import java.util.List;
+
 import com.google.common.base.Preconditions;
 
+import edu.washington.escience.myria.MyriaConstants;
 import edu.washington.escience.myria.Schema;
 import edu.washington.escience.myria.Type;
 import edu.washington.escience.myria.column.builder.ColumnBuilder;
@@ -484,26 +487,37 @@ public final class TupleUtils {
     }
     return true;
   }
+
+  /**
+   * batch size for tuple batch depending on a list of types.
+   * @param types types.
+   * @return batch size.
+   */
+  public static int getBatchSize(List<Type> types) {
+    if (types.contains(Type.BLOB_TYPE)) {
+      return 1;
+    }
+    return MyriaConstants.TUPLE_BATCH_DEFAULT_SIZE;
+  }
+
   /**
    * batch size for tuple batch depending on schema.
    * @param schema of tuplebatch
-   * @return batchsize.
+   * @return batch size.
    */
   public static int getBatchSize(Schema schema) {
-    int batchSize = 1000 * 10;
-    if (schema.getColumnTypes().indexOf(Type.BLOB_TYPE) >= 0) batchSize = 1;
-
-    return batchSize;
+    return getBatchSize(schema.getColumnTypes());
   }
+
   /**
    * batch size for column depending upon type.
    * @param type of column.
    * @return batchsize.
    */
   public static int getBatchSize(Type type) {
-    int batchSize = 1000 * 10;
-    if (type == Type.BLOB_TYPE) batchSize = 1;
-
-    return batchSize;
+    if (type == Type.BLOB_TYPE) {
+      return 1;
+    }
+    return MyriaConstants.TUPLE_BATCH_DEFAULT_SIZE;
   }
 }

--- a/test/edu/washington/escience/myria/column/BlobColumnTest.java
+++ b/test/edu/washington/escience/myria/column/BlobColumnTest.java
@@ -11,7 +11,6 @@ import java.nio.file.Paths;
 
 import org.junit.Test;
 
-import edu.washington.escience.myria.column.BlobColumn;
 import edu.washington.escience.myria.column.builder.BlobColumnBuilder;
 import edu.washington.escience.myria.proto.DataProto.ColumnMessage;
 
@@ -19,21 +18,17 @@ public class BlobColumnTest {
 
   @Test
   public void testProto() {
-
-    final BlobColumnBuilder original = new BlobColumnBuilder();
-
+    final BlobColumnBuilder original = new BlobColumnBuilder(1);
     original.appendBlob(ByteBuffer.wrap("Test1".getBytes()));
-
     final ColumnMessage serialized = original.build().serializeToProto();
     final BlobColumn deserialized =
         BlobColumnBuilder.buildFromProtobuf(serialized, original.size());
-
     assertTrue(original.size() == deserialized.size());
   }
 
   @Test(expected = BufferOverflowException.class)
   public void testFull() {
-    final BlobColumnBuilder original = new BlobColumnBuilder();
+    final BlobColumnBuilder original = new BlobColumnBuilder(6);
     original
         .appendBlob(ByteBuffer.wrap("First".getBytes()))
         .appendBlob(ByteBuffer.wrap("Second".getBytes()))
@@ -46,12 +41,10 @@ public class BlobColumnTest {
 
   protected byte[] readbb() {
     Path filename = Paths.get(Paths.get("testdata", "pythonUDF", "1.p").toString());
-
     byte[] data = null;
     try {
       data = Files.readAllBytes(filename);
     } catch (IOException e) {
-
       e.printStackTrace();
     }
     return data;

--- a/test/edu/washington/escience/myria/column/BooleanColumnTest.java
+++ b/test/edu/washington/escience/myria/column/BooleanColumnTest.java
@@ -6,21 +6,18 @@ import java.nio.BufferOverflowException;
 
 import org.junit.Test;
 
-import com.google.inject.util.Types;
 import edu.washington.escience.myria.Type;
 //import com.sun.org.apache.xalan.internal.xsltc.compiler.util.Type;
-
-import edu.washington.escience.myria.column.BooleanColumn;
 import edu.washington.escience.myria.column.builder.BooleanColumnBuilder;
 import edu.washington.escience.myria.proto.DataProto.ColumnMessage;
-import edu.washington.escience.myria.storage.TupleBatch;
 import edu.washington.escience.myria.storage.TupleUtils;
 
 public class BooleanColumnTest {
+  private int size = TupleUtils.getBatchSize(Type.BOOLEAN_TYPE);
 
   @Test
   public void testProto() {
-    final BooleanColumnBuilder original = new BooleanColumnBuilder();
+    final BooleanColumnBuilder original = new BooleanColumnBuilder(size);
     original
         .appendBoolean(true)
         .appendBoolean(false)
@@ -44,8 +41,8 @@ public class BooleanColumnTest {
 
   @Test
   public void testFull() {
-    final BooleanColumnBuilder builder = new BooleanColumnBuilder();
-    for (int i = 0; i < TupleUtils.getBatchSize(Type.BOOLEAN_TYPE); i++) {
+    final BooleanColumnBuilder builder = new BooleanColumnBuilder(size);
+    for (int i = 0; i < size; i++) {
       builder.appendBoolean(true);
     }
     builder.build();
@@ -53,8 +50,8 @@ public class BooleanColumnTest {
 
   @Test(expected = BufferOverflowException.class)
   public void testOverflow() {
-    final BooleanColumnBuilder builder = new BooleanColumnBuilder();
-    for (int i = 0; i < TupleUtils.getBatchSize(Type.BOOLEAN_TYPE); i++) {
+    final BooleanColumnBuilder builder = new BooleanColumnBuilder(size);
+    for (int i = 0; i < size; i++) {
       builder.appendBoolean(false);
     }
     builder.appendBoolean(true);

--- a/test/edu/washington/escience/myria/column/DateTimeColumnTest.java
+++ b/test/edu/washington/escience/myria/column/DateTimeColumnTest.java
@@ -8,18 +8,17 @@ import org.joda.time.DateTime;
 import org.junit.Test;
 
 import edu.washington.escience.myria.Type;
-import edu.washington.escience.myria.column.DateTimeColumn;
 import edu.washington.escience.myria.column.builder.DateTimeColumnBuilder;
 import edu.washington.escience.myria.proto.DataProto.ColumnMessage;
-import edu.washington.escience.myria.storage.TupleBatch;
 import edu.washington.escience.myria.storage.TupleUtils;
 import edu.washington.escience.myria.util.DateTimeUtils;
 
 public class DateTimeColumnTest {
+  final int size = TupleUtils.getBatchSize(Type.DATETIME_TYPE);
 
   @Test
   public void testProto() {
-    final DateTimeColumnBuilder original = new DateTimeColumnBuilder();
+    final DateTimeColumnBuilder original = new DateTimeColumnBuilder(4);
     original
         .appendDateTime(DateTimeUtils.parse("2000-02-03"))
         .appendDateTime(DateTimeUtils.parse("2000-02-03"))
@@ -33,8 +32,8 @@ public class DateTimeColumnTest {
 
   @Test
   public void testFull() {
-    final DateTimeColumnBuilder builder = new DateTimeColumnBuilder();
-    for (int i = 0; i < TupleUtils.getBatchSize(Type.DATETIME_TYPE); i++) {
+    final DateTimeColumnBuilder builder = new DateTimeColumnBuilder(size);
+    for (int i = 0; i < size; i++) {
       builder.appendDateTime(new DateTime());
     }
     builder.build();
@@ -42,8 +41,8 @@ public class DateTimeColumnTest {
 
   @Test(expected = BufferOverflowException.class)
   public void testOverflow() {
-    final DateTimeColumnBuilder builder = new DateTimeColumnBuilder();
-    for (int i = 0; i < TupleUtils.getBatchSize(Type.DATETIME_TYPE); i++) {
+    final DateTimeColumnBuilder builder = new DateTimeColumnBuilder(size);
+    for (int i = 0; i < size; i++) {
       builder.appendDateTime(new DateTime());
     }
     builder.appendDateTime(new DateTime());

--- a/test/edu/washington/escience/myria/column/DoubleColumnTest.java
+++ b/test/edu/washington/escience/myria/column/DoubleColumnTest.java
@@ -9,14 +9,14 @@ import org.junit.Test;
 import edu.washington.escience.myria.Type;
 import edu.washington.escience.myria.column.builder.DoubleColumnBuilder;
 import edu.washington.escience.myria.proto.DataProto.ColumnMessage;
-import edu.washington.escience.myria.storage.TupleBatch;
 import edu.washington.escience.myria.storage.TupleUtils;
 
 public class DoubleColumnTest {
+  final int size = TupleUtils.getBatchSize(Type.DOUBLE_TYPE);
 
   @Test
   public void testProto() {
-    final DoubleColumnBuilder original = new DoubleColumnBuilder();
+    final DoubleColumnBuilder original = new DoubleColumnBuilder(size);
     original.appendDouble(1).appendDouble(2).appendDouble(5).appendDouble(11);
     final ColumnMessage serialized = original.build().serializeToProto();
     final DoubleColumn deserialized =
@@ -26,8 +26,8 @@ public class DoubleColumnTest {
 
   @Test
   public void testFull() {
-    final DoubleColumnBuilder builder = new DoubleColumnBuilder();
-    for (int i = 0; i < TupleUtils.getBatchSize(Type.DOUBLE_TYPE); i++) {
+    final DoubleColumnBuilder builder = new DoubleColumnBuilder(size);
+    for (int i = 0; i < size; i++) {
       builder.appendDouble(i * 1.0);
     }
     builder.build();
@@ -35,8 +35,8 @@ public class DoubleColumnTest {
 
   @Test(expected = BufferOverflowException.class)
   public void testOverflow() {
-    final DoubleColumnBuilder builder = new DoubleColumnBuilder();
-    for (int i = 0; i < TupleUtils.getBatchSize(Type.DOUBLE_TYPE); i++) {
+    final DoubleColumnBuilder builder = new DoubleColumnBuilder(size);
+    for (int i = 0; i < size; i++) {
       builder.appendDouble(i * 1.0);
     }
     builder.appendDouble(0.0);

--- a/test/edu/washington/escience/myria/column/FloatColumnTest.java
+++ b/test/edu/washington/escience/myria/column/FloatColumnTest.java
@@ -7,17 +7,16 @@ import java.nio.BufferOverflowException;
 import org.junit.Test;
 
 import edu.washington.escience.myria.Type;
-import edu.washington.escience.myria.column.FloatColumn;
 import edu.washington.escience.myria.column.builder.FloatColumnBuilder;
 import edu.washington.escience.myria.proto.DataProto.ColumnMessage;
-import edu.washington.escience.myria.storage.TupleBatch;
 import edu.washington.escience.myria.storage.TupleUtils;
 
 public class FloatColumnTest {
+  final int size = TupleUtils.getBatchSize(Type.FLOAT_TYPE);
 
   @Test
   public void testProto() {
-    final FloatColumnBuilder original = new FloatColumnBuilder();
+    final FloatColumnBuilder original = new FloatColumnBuilder(size);
     original.appendFloat(1.0f).appendFloat(2.0f).appendFloat(5.0f).appendFloat(11.0f);
     FloatColumn column = original.build();
     final ColumnMessage serialized = column.serializeToProto();
@@ -31,8 +30,8 @@ public class FloatColumnTest {
 
   @Test
   public void testFull() {
-    final FloatColumnBuilder builder = new FloatColumnBuilder();
-    for (int i = 0; i < TupleUtils.getBatchSize(Type.FLOAT_TYPE); i++) {
+    final FloatColumnBuilder builder = new FloatColumnBuilder(size);
+    for (int i = 0; i < size; i++) {
       builder.appendFloat(i * 1.0f);
     }
     builder.build();
@@ -40,8 +39,8 @@ public class FloatColumnTest {
 
   @Test(expected = BufferOverflowException.class)
   public void testOverflow() {
-    final FloatColumnBuilder builder = new FloatColumnBuilder();
-    for (int i = 0; i < TupleUtils.getBatchSize(Type.FLOAT_TYPE); i++) {
+    final FloatColumnBuilder builder = new FloatColumnBuilder(size);
+    for (int i = 0; i < size; i++) {
       builder.appendFloat(i * 1.0f);
     }
     builder.appendFloat(0.0f);

--- a/test/edu/washington/escience/myria/column/IntColumnTest.java
+++ b/test/edu/washington/escience/myria/column/IntColumnTest.java
@@ -10,14 +10,14 @@ import org.junit.Test;
 import edu.washington.escience.myria.Type;
 import edu.washington.escience.myria.column.builder.IntColumnBuilder;
 import edu.washington.escience.myria.proto.DataProto.ColumnMessage;
-import edu.washington.escience.myria.storage.TupleBatch;
 import edu.washington.escience.myria.storage.TupleUtils;
 
 public class IntColumnTest {
+  final int size = TupleUtils.getBatchSize(Type.INT_TYPE);
 
   @Test
   public void testProto() {
-    final IntColumnBuilder original = new IntColumnBuilder();
+    final IntColumnBuilder original = new IntColumnBuilder(size);
     original.appendInt(1).appendInt(2).appendInt(5).appendInt(11);
     final ColumnMessage serialized = original.build().serializeToProto();
     assertEquals(ColumnMessage.Type.INT, serialized.getType());
@@ -27,7 +27,7 @@ public class IntColumnTest {
 
   @Test
   public void testIntProtoColumn() {
-    final IntColumnBuilder original = new IntColumnBuilder();
+    final IntColumnBuilder original = new IntColumnBuilder(size);
     original.appendInt(1).appendInt(2).appendInt(5).appendInt(11).appendInt(17);
     final ColumnMessage serialized = original.build().serializeToProto();
     assertEquals(ColumnMessage.Type.INT, serialized.getType());
@@ -37,8 +37,8 @@ public class IntColumnTest {
 
   @Test
   public void testFull() {
-    final IntColumnBuilder builder = new IntColumnBuilder();
-    for (int i = 0; i < TupleUtils.getBatchSize(Type.INT_TYPE); i++) {
+    final IntColumnBuilder builder = new IntColumnBuilder(size);
+    for (int i = 0; i < size; i++) {
       builder.appendInt(i);
     }
     builder.build();
@@ -46,11 +46,11 @@ public class IntColumnTest {
 
   @Test(expected = BufferOverflowException.class)
   public void testOverflow() {
-    final IntColumnBuilder builder = new IntColumnBuilder();
-    for (int i = 0; i < TupleUtils.getBatchSize(Type.INT_TYPE); i++) {
+    final IntColumnBuilder builder = new IntColumnBuilder(size);
+    for (int i = 0; i < size; i++) {
       builder.appendInt(i);
     }
-    builder.appendInt(TupleUtils.getBatchSize(Type.INT_TYPE));
+    builder.appendInt(0);
     builder.build();
   }
 }

--- a/test/edu/washington/escience/myria/column/LongColumnTest.java
+++ b/test/edu/washington/escience/myria/column/LongColumnTest.java
@@ -7,17 +7,16 @@ import java.nio.BufferOverflowException;
 import org.junit.Test;
 
 import edu.washington.escience.myria.Type;
-import edu.washington.escience.myria.column.LongColumn;
 import edu.washington.escience.myria.column.builder.LongColumnBuilder;
 import edu.washington.escience.myria.proto.DataProto.ColumnMessage;
-import edu.washington.escience.myria.storage.TupleBatch;
 import edu.washington.escience.myria.storage.TupleUtils;
 
 public class LongColumnTest {
+  final int size = TupleUtils.getBatchSize(Type.LONG_TYPE);
 
   @Test
   public void testProto() {
-    final LongColumnBuilder original = new LongColumnBuilder();
+    final LongColumnBuilder original = new LongColumnBuilder(size);
     original.appendLong(1).appendLong(2).appendLong(5).appendLong(11);
     final ColumnMessage serialized = original.build().serializeToProto();
     final LongColumn deserialized =
@@ -27,8 +26,8 @@ public class LongColumnTest {
 
   @Test
   public void testFull() {
-    final LongColumnBuilder builder = new LongColumnBuilder();
-    for (int i = 0; i < TupleUtils.getBatchSize(Type.LONG_TYPE); i++) {
+    final LongColumnBuilder builder = new LongColumnBuilder(size);
+    for (int i = 0; i < size; i++) {
       builder.appendLong(i);
     }
     builder.build();
@@ -36,8 +35,8 @@ public class LongColumnTest {
 
   @Test(expected = BufferOverflowException.class)
   public void testOverflow() {
-    final LongColumnBuilder builder = new LongColumnBuilder();
-    for (int i = 0; i < TupleUtils.getBatchSize(Type.LONG_TYPE); i++) {
+    final LongColumnBuilder builder = new LongColumnBuilder(size);
+    for (int i = 0; i < size; i++) {
       builder.appendLong(i);
     }
     builder.appendLong(0);

--- a/test/edu/washington/escience/myria/column/StringColumnTest.java
+++ b/test/edu/washington/escience/myria/column/StringColumnTest.java
@@ -7,17 +7,16 @@ import java.nio.BufferOverflowException;
 import org.junit.Test;
 
 import edu.washington.escience.myria.Type;
-import edu.washington.escience.myria.column.StringColumn;
 import edu.washington.escience.myria.column.builder.StringColumnBuilder;
 import edu.washington.escience.myria.proto.DataProto.ColumnMessage;
-import edu.washington.escience.myria.storage.TupleBatch;
 import edu.washington.escience.myria.storage.TupleUtils;
 
 public class StringColumnTest {
+  final int size = TupleUtils.getBatchSize(Type.STRING_TYPE);
 
   @Test
   public void testProto() {
-    final StringColumnBuilder original = new StringColumnBuilder();
+    final StringColumnBuilder original = new StringColumnBuilder(size);
     original
         .appendString("First")
         .appendString("Second")
@@ -33,8 +32,8 @@ public class StringColumnTest {
 
   @Test
   public void testFull() {
-    final StringColumnBuilder builder = new StringColumnBuilder();
-    for (int i = 0; i < TupleUtils.getBatchSize(Type.STRING_TYPE); i++) {
+    final StringColumnBuilder builder = new StringColumnBuilder(size);
+    for (int i = 0; i < size; i++) {
       builder.appendString("true");
     }
     builder.build();
@@ -42,8 +41,8 @@ public class StringColumnTest {
 
   @Test(expected = BufferOverflowException.class)
   public void testOverflow() {
-    final StringColumnBuilder builder = new StringColumnBuilder();
-    for (int i = 0; i < TupleUtils.getBatchSize(Type.STRING_TYPE); i++) {
+    final StringColumnBuilder builder = new StringColumnBuilder(size);
+    for (int i = 0; i < size; i++) {
       builder.appendString("false");
     }
     builder.appendString("true");

--- a/test/edu/washington/escience/myria/operator/AggregateTest.java
+++ b/test/edu/washington/escience/myria/operator/AggregateTest.java
@@ -200,7 +200,7 @@ public class AggregateTest {
 
       /* Ints, all as a group */
       int[] ints = new int[] {3, 5, 6};
-      builder = new IntColumnBuilder();
+      builder = new IntColumnBuilder(3);
       for (int i : ints) {
         builder.appendInt(i);
       }
@@ -229,7 +229,7 @@ public class AggregateTest {
 
       /* Longs */
       long[] longs = new long[] {3, 5, 9};
-      builder = new LongColumnBuilder();
+      builder = new LongColumnBuilder(3);
       for (long l : longs) {
         builder.appendLong(l);
       }
@@ -258,7 +258,7 @@ public class AggregateTest {
 
       /* Floats */
       float[] floats = new float[] {3, 5, 11};
-      builder = new FloatColumnBuilder();
+      builder = new FloatColumnBuilder(3);
       for (float f : floats) {
         builder.appendFloat(f);
       }
@@ -287,7 +287,7 @@ public class AggregateTest {
 
       /* Double */
       double[] doubles = new double[] {3, 5, 13};
-      builder = new DoubleColumnBuilder();
+      builder = new DoubleColumnBuilder(3);
       for (double d : doubles) {
         builder.appendDouble(d);
       }
@@ -332,7 +332,8 @@ public class AggregateTest {
             DateTime.parse("2014-04-01T11:31"),
             DateTime.parse("2012-02-29T12:00")
           };
-      builder = new DateTimeColumnBuilder();
+      builder = new DateTimeColumnBuilder(dates.length);
+
       for (DateTime d : dates) {
         builder.appendDateTime(d);
       }
@@ -344,7 +345,7 @@ public class AggregateTest {
 
       /* Strings */
       String[] strings = new String[] {"abcd", "abc", "abcde", "fghij0", "fghij1"};
-      builder = new StringColumnBuilder();
+      builder = new StringColumnBuilder(strings.length);
       for (String s : strings) {
         builder.appendString(s);
       }
@@ -357,7 +358,7 @@ public class AggregateTest {
       /* Booleans */
       AggregationOp[] booleanAggs = new AggregationOp[] {AggregationOp.COUNT};
       boolean[] booleans = new boolean[] {true, false, true};
-      builder = new BooleanColumnBuilder();
+      builder = new BooleanColumnBuilder(3);
       for (boolean b : booleans) {
         builder.appendBoolean(b);
       }
@@ -962,14 +963,14 @@ public class AggregateTest {
   @Test(expected = ArithmeticException.class)
   public void testLongAggOverflow() throws Exception {
     LongColumnBuilder builder =
-        new LongColumnBuilder().appendLong(Long.MAX_VALUE - 1).appendLong(3);
+        new LongColumnBuilder(2).appendLong(Long.MAX_VALUE - 1).appendLong(3);
     doAggOpsToCol(builder, new AggregationOp[] {AggregationOp.SUM}, true);
   }
 
   @Test(expected = ArithmeticException.class)
   public void testLongAggUnderflow() throws Exception {
     LongColumnBuilder builder =
-        new LongColumnBuilder().appendLong(Long.MIN_VALUE + 1).appendLong(-3);
+        new LongColumnBuilder(2).appendLong(Long.MIN_VALUE + 1).appendLong(-3);
     doAggOpsToCol(builder, new AggregationOp[] {AggregationOp.SUM}, true);
   }
 }

--- a/test/edu/washington/escience/myria/operator/StreamingAggTest.java
+++ b/test/edu/washington/escience/myria/operator/StreamingAggTest.java
@@ -1103,7 +1103,7 @@ public class StreamingAggTest {
     // min
     assertEquals(0, result.getLong(1, 0));
     // max
-    assertEquals(19999, result.getLong(2, 0));
+    assertEquals(numTuples - 1, result.getLong(2, 0));
     // count
     assertEquals(numTuples, result.getLong(3, 0));
     // sum

--- a/test/edu/washington/escience/myria/operator/apply/ApplyTest.java
+++ b/test/edu/washington/escience/myria/operator/apply/ApplyTest.java
@@ -3,6 +3,7 @@ package edu.washington.escience.myria.operator.apply;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 
 import org.junit.Test;
@@ -68,15 +69,22 @@ public class ApplyTest {
     final Schema schema =
         new Schema(
             ImmutableList.of(
-                Type.LONG_TYPE, Type.LONG_TYPE, Type.INT_TYPE, Type.STRING_TYPE, Type.BOOLEAN_TYPE),
-            ImmutableList.of("a", "b", "c", "d", "e"));
+                Type.LONG_TYPE,
+                Type.LONG_TYPE,
+                Type.INT_TYPE,
+                Type.STRING_TYPE,
+                Type.BOOLEAN_TYPE,
+                Type.BLOB_TYPE),
+            ImmutableList.of("a", "b", "c", "d", "e", "f"));
     final TupleBatchBuffer tbb = new TupleBatchBuffer(schema);
+    byte[] bytes = {(byte) 0xDE, (byte) 0xAD, (byte) 0xBE, (byte) 0xEF};
     for (long i = 0; i < NUM_TUPLES; i++) {
       tbb.putLong(0, (long) Math.pow(i, 2));
       tbb.putLong(1, i + 1);
       tbb.putInt(2, (int) i);
       tbb.putString(3, "Foo" + i);
       tbb.putBoolean(4, i % 2 == 0);
+      tbb.putBlob(5, ByteBuffer.wrap(bytes));
     }
     ImmutableList.Builder<Expression> Expressions = ImmutableList.builder();
 


### PR DESCRIPTION
By default, a column builder reserves 10k data except `BlobColumnBuilder`. However, when a list of columns (including a blob column) is allocated, the blob column is of size 1 while other columns are of size 10k. This caused OOM when we modified `ApplyTest.testApply()` by adding a blob column to its schema -- since each `TupleBatch` is now of size 1, the test created 20k `TupleBatch`es, each has a few columns of size 10k (and one blob column of size 1). 
Fix this bug by passing the size to a column builder, instead of getting its size based on its type internally.